### PR TITLE
polish translations: minutes

### DIFF
--- a/po/pl.po
+++ b/po/pl.po
@@ -572,7 +572,7 @@ msgstr "wygaszacz ekranu jest już uruchomiony w tej sesji"
 #. GDateTime.html#g-date-time-format
 #: ../src/gs-lock-plug.c:304
 msgid "%l:%M %p"
-msgstr "%k:M"
+msgstr "%k:%M"
 
 #. Translators: Date format, see https://developer.gnome.org/glib/stable/glib-
 #. GDateTime.html#g-date-time-format


### PR DESCRIPTION
In polish translations, there seem to be missing a '%' character. When I lock my screen and try to unlock it, the time is (for example), 09:M (obviously, M should be replaced by current minutes).
