### PR TITLE
Honor locale time settings in lock screen.

### DIFF
--- a/src/gs-lock-plug.c
+++ b/src/gs-lock-plug.c
@@ -300,10 +300,8 @@ date_time_update (GSLockPlug *plug)
 	gchar *str;
 
 	datetime = g_date_time_new_now_local ();
-	/* Translators: Time format, see https://developer.gnome.org/glib/stable/glib-GDateTime.html#g-date-time-format */
-	time = g_date_time_format (datetime, _("%l:%M %p"));
-	/* Translators: Date format, see https://developer.gnome.org/glib/stable/glib-GDateTime.html#g-date-time-format */
-	date = g_date_time_format (datetime, _("%A, %B %e"));
+	time = g_date_time_format (datetime, "%X");
+	date = g_date_time_format (datetime, "%x");
 
 	str = g_strdup_printf ("<span size=\"xx-large\" weight=\"ultrabold\">%s</span>", time);
 	gtk_label_set_text (GTK_LABEL (plug->priv->auth_time_label), str);


### PR DESCRIPTION
The time display in the lock screen should honor the LC_TIME variable,
including the locale-specific settings for whether to display a 12-hour or
24-hour time.  Sending the time and date strings through gettext results in
a value which is specific to LC_MESSAGES, which can be different from
LC_TIME.  Use the %X value for a time, which is guaranteed to be appropriate
for the locale in question.

In my particular case, I use UTC for my system time even though I live in the United States, so a 12-hour time is not very useful to me. I set LC_TIME to POSIX and LC_MESSAGES (and all the rest of the locale variables) to en_US.UTF-8, so passing the locale strings through gettext breaks things for me. Assuming people set their locales correctly, everything should just work.
