### PR TITLE
Don't fade to black when locking the screen

### DIFF
--- a/src/gs-manager.c
+++ b/src/gs-manager.c
@@ -1842,7 +1842,7 @@ gs_manager_activate (GSManager *manager)
 	manager->priv->active = TRUE;
 
 	/* fade to black and show windows */
-	do_fade = TRUE;
+	do_fade = FALSE;
 	if (do_fade)
 	{
 		manager->priv->fading = TRUE;


### PR DESCRIPTION
Fading to black has negative security consequences: the screen locking
and actual suspend race with each other, and this can result in the
screen's contents being briefly visible after resume.

This has been reported as #54 but has been known and patched for in
Debian/Ubuntu since at least 2010 (see LP 546578).