### PR TITLE
Fix broken systemd support

### DIFF
--- a/src/gs-listener-dbus.c
+++ b/src/gs-listener-dbus.c
@@ -1541,21 +1541,10 @@ _listener_message_path_is_our_session (GSListener  *listener,
 		return FALSE;
 
 	if (listener->priv->session_id == NULL)
-	return FALSE;
+		return FALSE;
 
-#ifdef WITH_SYSTEMD
-	/* The bus object path is simply the actual session ID
-	* prefixed to make it a bus path */
-	if (listener->priv->have_systemd)
-		return g_str_has_prefix (ssid, SYSTEMD_LOGIND_SESSION_PATH "/")
-			&& strcmp (ssid + sizeof (SYSTEMD_LOGIND_SESSION_PATH),
-			listener->priv->session_id) == 0;
-#endif
-
-#ifdef WITH_CONSOLE_KIT
 	if (strcmp (ssid, listener->priv->session_id) == 0)
 		return TRUE;
-#endif
 
 	return FALSE;
 }
@@ -2340,20 +2329,45 @@ query_session_id (GSListener *listener)
 
 #ifdef WITH_SYSTEMD
 	if (listener->priv->have_systemd) {
-		char *t;
-		int r;
+		dbus_uint32_t pid = getpid();
 
-		r = sd_pid_get_session (0, &t);
-		if (r < 0) {
-			gs_debug ("Couldn't determine our own session id: %s", strerror (-r));
+		message = dbus_message_new_method_call (SYSTEMD_LOGIND_SERVICE,
+		                                        SYSTEMD_LOGIND_PATH,
+							SYSTEMD_LOGIND_INTERFACE,
+							"GetSessionByPID");
+		if (message == NULL)
+		{
+			gs_debug ("Couldn't allocate the dbus message");
 			return NULL;
 		}
 
-		/* t is allocated with malloc(), we need it with g_malloc() */
-		ssid = g_strdup(t);
-		free (t);
+		if (dbus_message_append_args (message,
+					      DBUS_TYPE_UINT32,
+					      &pid, DBUS_TYPE_INVALID) == FALSE)
+		{
+			gs_debug ("Couldn't add args to the dbus message");
+			return NULL;
+		}
 
-		return ssid;
+		/* FIXME: use async? */
+		reply = dbus_connection_send_with_reply_and_block (listener->priv->system_connection,
+			message,
+			-1, &error);
+		dbus_message_unref (message);
+
+		if (dbus_error_is_set (&error))
+		{
+			gs_debug ("%s raised:\n %s\n\n", error.name, error.message);
+			dbus_error_free (&error);
+			return NULL;
+		}
+
+		dbus_message_iter_init (reply, &reply_iter);
+		dbus_message_iter_get_basic (&reply_iter, &ssid);
+
+		dbus_message_unref (reply);
+
+		return g_strdup (ssid);
 	}
 #endif
 

--- a/src/gs-listener-dbus.c
+++ b/src/gs-listener-dbus.c
@@ -1655,6 +1655,17 @@ listener_dbus_handle_system_message (DBusConnection *connection,
 			}
 
 			return DBUS_HANDLER_RESULT_HANDLED;
+		} else if (dbus_message_is_signal (message, SYSTEMD_LOGIND_INTERFACE, "PrepareForSleep")) {
+			gboolean active;
+			if (dbus_message_get_args (message, NULL,
+				                   DBUS_TYPE_BOOLEAN, &active,
+				                   DBUS_TYPE_INVALID) && active) {
+				gs_debug ("systemd notified that system is about to sleep");
+				g_signal_emit (listener, signals [LOCK], 0);
+			} else {
+				gs_debug ("cannot parse PrepareForSleep");
+			}
+			return DBUS_HANDLER_RESULT_HANDLED;
 		} else if (dbus_message_is_signal (message, DBUS_INTERFACE_PROPERTIES, "PropertiesChanged")) {
 
 			if (_listener_message_path_is_our_session (listener, message)) {
@@ -2269,6 +2280,12 @@ gs_listener_acquire (GSListener *listener,
 					    ",sender='"SYSTEMD_LOGIND_SERVICE"'"
 					    ",interface='"SYSTEMD_LOGIND_SESSION_INTERFACE"'"
 					    ",member='Lock'",
+					    NULL);
+			dbus_bus_add_match (listener->priv->system_connection,
+					    "type='signal'"
+					    ",sender='"SYSTEMD_LOGIND_SERVICE"'"
+					    ",interface='"SYSTEMD_LOGIND_INTERFACE"'"
+					    ",member='PrepareForSleep'",
 					    NULL);
 			dbus_bus_add_match (listener->priv->system_connection,
 					    "type='signal'"


### PR DESCRIPTION
The current state of support for systemd is completely broken — this fixes two things:
1) Actually handle Lock/Unlock etc. events for systemd; despite most of the code for it being there, it's never actually activated(!)
2) Handle the PrepareForSleep systemd event so that the screen actually locks when the system suspends by e.g. systemctl suspend.

The first one is probably the fix to mate-desktop/mate-session-manager#27 as well; I don't think this was actually a session manager bug.

Both of these probably belong in the 1.10.x branch as well.