### PR TITLE
GTK+-3 gs-grab-x11: use correct GTK_VERSION_CHECK

### DIFF
--- a/src/gs-grab-x11.c
+++ b/src/gs-grab-x11.c
@@ -73,7 +73,7 @@ grab_string (int status)
 		return "GrabNotViewable";
 	case GDK_GRAB_FROZEN:
 		return "GrabFrozen";
-#if GTK_CHECK_VERSION (3, 0, 0)
+#if GTK_CHECK_VERSION (3, 16, 0)
 	case GDK_GRAB_FAILED:
 		return "GrabFailed";
 #endif


### PR DESCRIPTION
fixes https://github.com/mate-desktop/mate-screensaver/issues/104
Issue was caused by https://github.com/mate-desktop/mate-screensaver/commit/051d9df1ca81e586f43d1d95a1ac3159452d4f17
@XRevan86 
Please test and review