### PR TITLE
Avoid deprecated gdk_window_set_background functions

### DIFF
--- a/data/mate-screensaver-preferences.ui
+++ b/data/mate-screensaver-preferences.ui
@@ -137,6 +137,7 @@
         <child>
           <object class="GtkDrawingArea" id="fullscreen_preview_area">
             <property name="visible">True</property>
+            <property name="app_paintable">True</property>
             <property name="can_focus">False</property>
           </object>
           <packing>
@@ -316,6 +317,7 @@
                             </child>
                             <child>
                               <object class="GtkDrawingArea" id="preview_area">
+                                <property name="app_paintable">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="hexpand">True</property>
                               </object>

--- a/savers/floaters.c
+++ b/savers/floaters.c
@@ -1050,8 +1050,9 @@ screen_saver_update_state (ScreenSaver *screen_saver,
 
 		screen_saver_floater_update_state (screen_saver, floater, time);
 
-		if (gtk_widget_get_realized (screen_saver->drawing_area)
-		        && (floater->bounds.width > 0) && (floater->bounds.height > 0))
+		if (screen_saver->drawing_area != NULL &&
+		    gtk_widget_get_realized (screen_saver->drawing_area) &&
+		    (floater->bounds.width > 0) && (floater->bounds.height > 0))
 		{
 			gint size;
 			size = CLAMP ((int) (FLOATER_MAX_SIZE * floater->scale),

--- a/savers/gs-theme-engine.c
+++ b/savers/gs-theme-engine.c
@@ -107,34 +107,15 @@ gs_theme_engine_get_property (GObject            *object,
 	}
 }
 
-static void
-gs_theme_engine_clear (GtkWidget *widget)
-{
-	GdkRGBA color = { 0.0, 0.0, 0.0, 1.0 };
-	GtkStateFlags state;
-
-	g_return_if_fail (GS_IS_THEME_ENGINE (widget));
-
-	if (! gtk_widget_get_visible (widget))
-	{
-		return;
-	}
-
-	state = gtk_widget_get_state_flags (widget);
-	gtk_widget_override_background_color (widget, state, &color);
-	gdk_window_set_background_rgba (gtk_widget_get_window (widget), &color);
-	gdk_flush ();
-}
-
 static gboolean
-gs_theme_engine_real_map_event (GtkWidget   *widget,
-                                GdkEventAny *event)
+gs_theme_engine_real_draw (GtkWidget *widget,
+                           cairo_t   *cr)
 {
-	gboolean handled = FALSE;
+	cairo_set_operator (cr, CAIRO_OPERATOR_OVER);
+	cairo_set_source_rgb (cr, 0, 0, 0);
+	cairo_paint (cr);
 
-	gs_theme_engine_clear (widget);
-
-	return handled;
+	return FALSE;
 }
 
 static void
@@ -149,7 +130,7 @@ gs_theme_engine_class_init (GSThemeEngineClass *klass)
 	object_class->get_property = gs_theme_engine_get_property;
 	object_class->set_property = gs_theme_engine_set_property;
 
-	widget_class->map_event = gs_theme_engine_real_map_event;
+	widget_class->draw = gs_theme_engine_real_draw;
 
 	g_type_class_add_private (klass, sizeof (GSThemeEnginePrivate));
 }

--- a/src/gs-fade.c
+++ b/src/gs-fade.c
@@ -310,7 +310,7 @@ gamma_fade_setup (GSFade *fade)
 
 
 		res = XF86VidModeGetGammaRampSize (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()),
-		                                   gdk_screen_get_number (gdk_screen_get_default ()),
+		                                   GDK_SCREEN_XNUMBER (gdk_screen_get_default ()),
 		                                   &screen_priv->info->size);
 		if (!res || screen_priv->info->size <= 0)
 		{
@@ -329,7 +329,7 @@ gamma_fade_setup (GSFade *fade)
 		}
 
 		res = XF86VidModeGetGammaRamp (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()),
-		                               gdk_screen_get_number (gdk_screen_get_default ()),
+		                               GDK_SCREEN_XNUMBER (gdk_screen_get_default ()),
 		                               screen_priv->info->size,
 		                               screen_priv->info->r,
 		                               screen_priv->info->g,
@@ -349,7 +349,7 @@ test_number:
 		/* only have gamma parameter, not ramps. */
 
 		res = XF86VidModeGetGamma (GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()),
-		                           gdk_screen_get_number (gdk_screen_get_default ()),
+		                           GDK_SCREEN_XNUMBER (gdk_screen_get_default ()),
 		                           &screen_priv->vmg);
 		if (! res)
 		{
@@ -406,7 +406,7 @@ gamma_fade_set_alpha_gamma (GSFade *fade,
                             gdouble alpha)
 {
 	struct GSFadeScreenPrivate *screen_priv;
-	int screen_idx = gdk_screen_get_number (gdk_screen_get_default ());
+	int screen_idx = GDK_SCREEN_XNUMBER (gdk_screen_get_default ());
 
 	screen_priv = &fade->priv->screen_priv;
 	xf86_whack_gamma (screen_idx, screen_priv, alpha);

--- a/src/gs-grab-x11.c
+++ b/src/gs-grab-x11.c
@@ -49,11 +49,11 @@ static gpointer grab_object = NULL;
 
 struct GSGrabPrivate
 {
-	guint      mouse_hide_cursor : 1;
-	GdkWindow *mouse_grab_window;
-	GdkWindow *keyboard_grab_window;
-	GdkScreen *mouse_grab_screen;
-	GdkScreen *keyboard_grab_screen;
+	guint       mouse_hide_cursor : 1;
+	GdkWindow  *mouse_grab_window;
+	GdkWindow  *keyboard_grab_window;
+	GdkDisplay *mouse_grab_display;
+	GdkDisplay *keyboard_grab_display;
 
 	GtkWidget *invisible;
 };
@@ -154,14 +154,14 @@ xorg_lock_smasher_set_active (GSGrab  *grab,
 #endif /* HAVE_XF86MISCSETGRABKEYSSTATE */
 
 static int
-gs_grab_get_keyboard (GSGrab    *grab,
-                      GdkWindow *window,
-                      GdkScreen *screen)
+gs_grab_get_keyboard (GSGrab     *grab,
+                      GdkWindow  *window,
+                      GdkDisplay *display)
 {
 	GdkGrabStatus status;
 
 	g_return_val_if_fail (window != NULL, FALSE);
-	g_return_val_if_fail (screen != NULL, FALSE);
+	g_return_val_if_fail (display != NULL, FALSE);
 
 	gs_debug ("Grabbing keyboard widget=%X", (guint32) GDK_WINDOW_XID (window));
 	status = gdk_keyboard_grab (window, FALSE, GDK_CURRENT_TIME);
@@ -178,7 +178,7 @@ gs_grab_get_keyboard (GSGrab    *grab,
 		g_object_add_weak_pointer (G_OBJECT (grab->priv->keyboard_grab_window),
 		                           (gpointer *) &grab->priv->keyboard_grab_window);
 
-		grab->priv->keyboard_grab_screen = screen;
+		grab->priv->keyboard_grab_display = display;
 	}
 	else
 	{
@@ -189,26 +189,18 @@ gs_grab_get_keyboard (GSGrab    *grab,
 }
 
 static int
-gs_grab_get_mouse (GSGrab    *grab,
-                   GdkWindow *window,
-                   GdkScreen *screen,
-                   gboolean   hide_cursor)
+gs_grab_get_mouse (GSGrab     *grab,
+                   GdkWindow  *window,
+                   GdkDisplay *display,
+                   gboolean    hide_cursor)
 {
 	GdkGrabStatus status;
-#if GTK_CHECK_VERSION (3, 16, 0)
-	GdkDisplay *display;
-#endif
 	GdkCursor    *cursor;
 
 	g_return_val_if_fail (window != NULL, FALSE);
-	g_return_val_if_fail (screen != NULL, FALSE);
+	g_return_val_if_fail (display != NULL, FALSE);
 
-#if GTK_CHECK_VERSION (3, 16, 0)
-	display = gdk_window_get_display (window);
 	cursor = gdk_cursor_new_for_display (display, GDK_BLANK_CURSOR);
-#else
-	cursor = gdk_cursor_new (GDK_BLANK_CURSOR);
-#endif
 
 	gs_debug ("Grabbing mouse widget=%X", (guint32) GDK_WINDOW_XID (window));
 	status = gdk_pointer_grab (window, TRUE, 0, NULL,
@@ -227,7 +219,7 @@ gs_grab_get_mouse (GSGrab    *grab,
 		g_object_add_weak_pointer (G_OBJECT (grab->priv->mouse_grab_window),
 		                           (gpointer *) &grab->priv->mouse_grab_window);
 
-		grab->priv->mouse_grab_screen = screen;
+		grab->priv->mouse_grab_display = display;
 		grab->priv->mouse_hide_cursor = hide_cursor;
 	}
 
@@ -245,7 +237,7 @@ gs_grab_keyboard_reset (GSGrab *grab)
 		                              (gpointer *) &grab->priv->keyboard_grab_window);
 	}
 	grab->priv->keyboard_grab_window = NULL;
-	grab->priv->keyboard_grab_screen = NULL;
+	grab->priv->keyboard_grab_display = NULL;
 }
 
 static gboolean
@@ -269,7 +261,7 @@ gs_grab_mouse_reset (GSGrab *grab)
 	}
 
 	grab->priv->mouse_grab_window = NULL;
-	grab->priv->mouse_grab_screen = NULL;
+	grab->priv->mouse_grab_display = NULL;
 }
 
 gboolean
@@ -284,15 +276,15 @@ gs_grab_release_mouse (GSGrab *grab)
 }
 
 static gboolean
-gs_grab_move_mouse (GSGrab    *grab,
-                    GdkWindow *window,
-                    GdkScreen *screen,
-                    gboolean   hide_cursor)
+gs_grab_move_mouse (GSGrab     *grab,
+                    GdkWindow  *window,
+                    GdkDisplay *display,
+                    gboolean    hide_cursor)
 {
 	gboolean    result;
 	GdkWindow  *old_window;
-	GdkScreen  *old_screen;
-	gboolean   old_hide_cursor;
+	GdkDisplay *old_display;
+	gboolean    old_hide_cursor;
 
 
 	/* if the pointer is not grabbed and we have a
@@ -331,7 +323,7 @@ gs_grab_move_mouse (GSGrab    *grab,
 	gdk_x11_grab_server ();
 
 	old_window = grab->priv->mouse_grab_window;
-	old_screen = grab->priv->mouse_grab_screen;
+	old_display = grab->priv->mouse_grab_display;
 	old_hide_cursor = grab->priv->mouse_hide_cursor;
 
 	if (old_window)
@@ -339,18 +331,18 @@ gs_grab_move_mouse (GSGrab    *grab,
 		gs_grab_release_mouse (grab);
 	}
 
-	result = gs_grab_get_mouse (grab, window, screen, hide_cursor);
+	result = gs_grab_get_mouse (grab, window, display, hide_cursor);
 
 	if (result != GDK_GRAB_SUCCESS)
 	{
 		sleep (1);
-		result = gs_grab_get_mouse (grab, window, screen, hide_cursor);
+		result = gs_grab_get_mouse (grab, window, display, hide_cursor);
 	}
 
 	if ((result != GDK_GRAB_SUCCESS) && old_window)
 	{
 		gs_debug ("Could not grab mouse for new window.  Resuming previous grab.");
-		gs_grab_get_mouse (grab, old_window, old_screen, old_hide_cursor);
+		gs_grab_get_mouse (grab, old_window, old_display, old_hide_cursor);
 	}
 
 	gs_debug ("*** releasing X server grab");
@@ -361,13 +353,13 @@ gs_grab_move_mouse (GSGrab    *grab,
 }
 
 static gboolean
-gs_grab_move_keyboard (GSGrab    *grab,
-                       GdkWindow *window,
-                       GdkScreen *screen)
+gs_grab_move_keyboard (GSGrab     *grab,
+                       GdkWindow  *window,
+                       GdkDisplay *display)
 {
 	gboolean    result;
 	GdkWindow  *old_window;
-	GdkScreen  *old_screen;
+	GdkDisplay *old_display;
 
 	if (grab->priv->keyboard_grab_window == window)
 	{
@@ -393,25 +385,25 @@ gs_grab_move_keyboard (GSGrab    *grab,
 	gdk_x11_grab_server ();
 
 	old_window = grab->priv->keyboard_grab_window;
-	old_screen = grab->priv->keyboard_grab_screen;
+	old_display = grab->priv->keyboard_grab_display;
 
 	if (old_window)
 	{
 		gs_grab_release_keyboard (grab);
 	}
 
-	result = gs_grab_get_keyboard (grab, window, screen);
+	result = gs_grab_get_keyboard (grab, window, display);
 
 	if (result != GDK_GRAB_SUCCESS)
 	{
 		sleep (1);
-		result = gs_grab_get_keyboard (grab, window, screen);
+		result = gs_grab_get_keyboard (grab, window, display);
 	}
 
 	if ((result != GDK_GRAB_SUCCESS) && old_window)
 	{
-		gs_debug ("Could not grab keyboard for new window.  Resuming previous grab.");
-		gs_grab_get_keyboard (grab, old_window, old_screen);
+		gs_debug ("Could not grab keyboard for new window. Resuming previous grab.");
+		gs_grab_get_keyboard (grab, old_window, old_display);
 	}
 
 	gs_debug ("*** releasing X server grab");
@@ -453,10 +445,10 @@ gs_grab_release (GSGrab *grab)
 }
 
 gboolean
-gs_grab_grab_window (GSGrab    *grab,
-                     GdkWindow *window,
-                     GdkScreen *screen,
-                     gboolean   hide_cursor)
+gs_grab_grab_window (GSGrab     *grab,
+                     GdkWindow  *window,
+                     GdkDisplay *display,
+                     gboolean    hide_cursor)
 {
 	gboolean    mstatus = FALSE;
 	gboolean    kstatus = FALSE;
@@ -468,7 +460,7 @@ AGAIN:
 
 	for (i = 0; i < retries; i++)
 	{
-		kstatus = gs_grab_get_keyboard (grab, window, screen);
+		kstatus = gs_grab_get_keyboard (grab, window, display);
 		if (kstatus == GDK_GRAB_SUCCESS)
 		{
 			break;
@@ -490,7 +482,7 @@ AGAIN:
 
 	for (i = 0; i < retries; i++)
 	{
-		mstatus = gs_grab_get_mouse (grab, window, screen, hide_cursor);
+		mstatus = gs_grab_get_mouse (grab, window, display, hide_cursor);
 		if (mstatus == GDK_GRAB_SUCCESS)
 		{
 			break;
@@ -565,7 +557,7 @@ gs_grab_grab_root (GSGrab  *grab,
 	gdk_device_get_position (device, &screen, NULL, NULL);
 	root = gdk_screen_get_root_window (screen);
 
-	res = gs_grab_grab_window (grab, root, screen, hide_cursor);
+	res = gs_grab_grab_window (grab, root, display, hide_cursor);
 
 	return res;
 }
@@ -575,23 +567,28 @@ gboolean
 gs_grab_grab_offscreen (GSGrab *grab,
                         gboolean hide_cursor)
 {
-	GdkScreen *screen;
-	gboolean   res;
+	GdkDisplay *display;
+	GdkScreen  *screen;
+	gboolean    res;
 
 	gs_debug ("Grabbing an offscreen window");
 
 	screen = gtk_invisible_get_screen (GTK_INVISIBLE (grab->priv->invisible));
-	res = gs_grab_grab_window (grab, gtk_widget_get_window (GTK_WIDGET (grab->priv->invisible)), screen, hide_cursor);
+	display = gdk_screen_get_display (screen);
+	res = gs_grab_grab_window (grab,
+	                           gtk_widget_get_window (GTK_WIDGET (grab->priv->invisible)),
+	                           display,
+	                           hide_cursor);
 
 	return res;
 }
 
 /* This is similar to gs_grab_grab_window but doesn't fail */
 void
-gs_grab_move_to_window (GSGrab    *grab,
-                        GdkWindow *window,
-                        GdkScreen *screen,
-                        gboolean   hide_cursor)
+gs_grab_move_to_window (GSGrab     *grab,
+                        GdkWindow  *window,
+                        GdkDisplay *display,
+                        gboolean    hide_cursor)
 {
 	gboolean result = FALSE;
 
@@ -601,14 +598,14 @@ gs_grab_move_to_window (GSGrab    *grab,
 
 	do
 	{
-		result = gs_grab_move_keyboard (grab, window, screen);
+		result = gs_grab_move_keyboard (grab, window, display);
 		gdk_flush ();
 	}
 	while (!result);
 
 	do
 	{
-		result = gs_grab_move_mouse (grab, window, screen, hide_cursor);
+		result = gs_grab_move_mouse (grab, window, display, hide_cursor);
 		gdk_flush ();
 	}
 	while (!result);

--- a/src/gs-grab.h
+++ b/src/gs-grab.h
@@ -56,20 +56,20 @@ GSGrab  * gs_grab_new              (void);
 void      gs_grab_release          (GSGrab    *grab);
 gboolean  gs_grab_release_mouse    (GSGrab    *grab);
 
-gboolean  gs_grab_grab_window      (GSGrab    *grab,
-                                    GdkWindow *window,
-                                    GdkScreen *screen,
-                                    gboolean   hide_cursor);
+gboolean  gs_grab_grab_window      (GSGrab     *grab,
+                                    GdkWindow  *window,
+                                    GdkDisplay *display,
+                                    gboolean    hide_cursor);
 
 gboolean  gs_grab_grab_root        (GSGrab    *grab,
                                     gboolean   hide_cursor);
 gboolean  gs_grab_grab_offscreen   (GSGrab    *grab,
                                     gboolean   hide_cursor);
 
-void      gs_grab_move_to_window   (GSGrab    *grab,
-                                    GdkWindow *window,
-                                    GdkScreen *screen,
-                                    gboolean   hide_cursor);
+void      gs_grab_move_to_window   (GSGrab     *grab,
+                                    GdkWindow  *window,
+                                    GdkDisplay *display,
+                                    gboolean    hide_cursor);
 
 void      gs_grab_mouse_reset      (GSGrab    *grab);
 void      gs_grab_keyboard_reset   (GSGrab    *grab);

--- a/src/gs-job.c
+++ b/src/gs-job.c
@@ -260,9 +260,10 @@ nice_process (int pid,
 static GPtrArray *
 get_env_vars (GtkWidget *widget)
 {
-	GPtrArray *env;
-	char      *str;
-	int        i;
+	GPtrArray   *env;
+	const gchar *display_name;
+	gchar       *str;
+	int          i;
 	static const char *allowed_env_vars [] =
 	{
 		"PATH",
@@ -276,9 +277,8 @@ get_env_vars (GtkWidget *widget)
 
 	env = g_ptr_array_new ();
 
-	str = gdk_screen_make_display_name (gtk_widget_get_screen (widget));
-	g_ptr_array_add (env, g_strdup_printf ("DISPLAY=%s", str));
-	g_free (str);
+	display_name = gdk_display_get_name (gtk_widget_get_display (widget));
+	g_ptr_array_add (env, g_strdup_printf ("DISPLAY=%s", display_name));
 
 	g_ptr_array_add (env, g_strdup_printf ("HOME=%s",
 	                                       g_get_home_dir ()));

--- a/src/gs-manager.c
+++ b/src/gs-manager.c
@@ -1102,12 +1102,15 @@ static GSWindow *
 find_window_at_pointer (GSManager *manager)
 {
 	GdkDisplay *display;
-	GdkScreen  *screen;
 	GdkDevice  *device;
+#if GTK_CHECK_VERSION (3, 22, 0)
+	GdkMonitor *monitor;
+#else
+	GdkScreen  *screen;
 	int         monitor;
+#endif
 	int         x, y;
 	GSWindow   *window;
-	int         screen_num;
 	GSList     *l;
 
 	display = gdk_display_get_default ();
@@ -1117,17 +1120,21 @@ find_window_at_pointer (GSManager *manager)
 #else
 	device = gdk_device_manager_get_client_pointer (gdk_display_get_device_manager (display));
 #endif
+#if GTK_CHECK_VERSION (3, 22, 0)
+	gdk_device_get_position (device, NULL, &x, &y);
+	monitor = gdk_display_get_monitor_at_point (display, x, y);
+#else
 	gdk_device_get_position (device, &screen, &x, &y);
 	monitor = gdk_screen_get_monitor_at_point (screen, x, y);
-	screen_num = gdk_screen_get_number (screen);
+#endif
 
-	/* Find the gs-window that is on that screen */
+	/* Find the gs-window that is on that monitor */
 	window = NULL;
 	for (l = manager->priv->windows; l; l = l->next)
 	{
 		GSWindow *win = GS_WINDOW (l->data);
-		if (gs_window_get_screen (win) == screen
-		        && gs_window_get_monitor (win) == monitor)
+		if (gs_window_get_display (win) == display &&
+		    gs_window_get_monitor (win) == monitor)
 		{
 			window = win;
 		}
@@ -1135,13 +1142,15 @@ find_window_at_pointer (GSManager *manager)
 
 	if (window == NULL)
 	{
-		gs_debug ("WARNING: Could not find the GSWindow for screen %d", screen_num);
+		gs_debug ("WARNING: Could not find the GSWindow for display %s",
+		          gdk_display_get_name (display));
 		/* take the first one */
 		window = manager->priv->windows->data;
 	}
 	else
 	{
-		gs_debug ("Requesting unlock for screen %d", screen_num);
+		gs_debug ("Requesting unlock for display %s",
+		          gdk_display_get_name (display));
 	}
 
 	return window;
@@ -1169,9 +1178,13 @@ manager_maybe_grab_window (GSManager *manager,
                            GSWindow  *window)
 {
 	GdkDisplay *display;
-	GdkScreen  *screen;
 	GdkDevice  *device;
+#if GTK_CHECK_VERSION (3, 22, 0)
+	GdkMonitor *monitor;
+#else
+	GdkScreen  *screen;
 	int         monitor;
+#endif
 	int         x, y;
 	gboolean    grabbed;
 
@@ -1181,18 +1194,23 @@ manager_maybe_grab_window (GSManager *manager,
 #else
 	device = gdk_device_manager_get_client_pointer (gdk_display_get_device_manager (display));
 #endif
+#if GTK_CHECK_VERSION (3, 22, 0)
+	gdk_device_get_position (device, NULL, &x, &y);
+	monitor = gdk_display_get_monitor_at_point (display, x, y);
+#else
 	gdk_device_get_position (device, &screen, &x, &y);
 	monitor = gdk_screen_get_monitor_at_point (screen, x, y);
+#endif
 
 	gdk_flush ();
 	grabbed = FALSE;
-	if (gs_window_get_screen (window) == screen
-	        && gs_window_get_monitor (window) == monitor)
+	if (gs_window_get_display (window) == display &&
+	    gs_window_get_monitor (window) == monitor)
 	{
 		gs_debug ("Moving grab to %p", window);
 		gs_grab_move_to_window (manager->priv->grab,
 		                        gs_window_get_gdk_window (window),
-		                        gs_window_get_screen (window),
+		                        gs_window_get_display (window),
 		                        FALSE);
 		grabbed = TRUE;
 	}
@@ -1266,6 +1284,7 @@ apply_background_to_window (GSManager *manager,
                             GSWindow  *window)
 {
 	cairo_surface_t *surface;
+	GdkDisplay      *display;
 	GdkScreen       *screen;
 	int              width;
 	int              height;
@@ -1278,7 +1297,8 @@ apply_background_to_window (GSManager *manager,
 		gs_window_set_background_surface (window, NULL);
 	}
 
-	screen = gs_window_get_screen (window);
+	display = gs_window_get_display (window);
+	screen = gdk_display_get_default_screen (display);
 	width = gdk_screen_get_width (screen);
 	height = gdk_screen_get_height (screen);
 	gs_debug ("Creating background w:%d h:%d", width, height);
@@ -1397,7 +1417,7 @@ handle_window_dialog_up (GSManager *manager,
 	/* Move keyboard and mouse grabs so dialog can be used */
 	gs_grab_move_to_window (manager->priv->grab,
 	                        gs_window_get_gdk_window (window),
-	                        gs_window_get_screen (window),
+	                        gs_window_get_display (window),
 	                        FALSE);
 
 	/* Release the pointer grab while dialog is up so that
@@ -1426,7 +1446,7 @@ handle_window_dialog_down (GSManager *manager,
 	/* Regrab the mouse */
 	gs_grab_move_to_window (manager->priv->grab,
 	                        gs_window_get_gdk_window (window),
-	                        gs_window_get_screen (window),
+	                        gs_window_get_display (window),
 	                        FALSE);
 
 	/* Make all windows sensitive so we get events */
@@ -1524,19 +1544,32 @@ connect_window_signals (GSManager *manager,
 }
 
 static void
-gs_manager_create_window_for_monitor (GSManager *manager,
-                                      GdkScreen *screen,
-                                      int        monitor)
+gs_manager_create_window_for_monitor (GSManager  *manager,
+#if GTK_CHECK_VERSION (3, 22, 0)
+                                      GdkMonitor *monitor)
+#else
+                                      GdkDisplay *display,
+                                      int         monitor)
+#endif
 {
 	GSWindow    *window;
+#if GTK_CHECK_VERSION (3, 22, 0)
+	GdkDisplay  *display;
+#endif
 	GdkRectangle rect;
 
-	gdk_screen_get_monitor_geometry (screen, monitor, &rect);
+#if GTK_CHECK_VERSION (3, 22, 0)
+	display = gdk_monitor_get_display (monitor);
+	gdk_monitor_get_geometry (monitor, &rect);
+#else
+	gdk_screen_get_monitor_geometry (gdk_display_get_default_screen (display),
+	                                 monitor, &rect);
+#endif
 
-	gs_debug ("Creating window for monitor %d [%d,%d] (%dx%d)",
+	gs_debug ("Creating a window for the monitor [%d,%d] (%dx%d)",
 	          monitor, rect.x, rect.y, rect.width, rect.height);
 
-	window = gs_window_new (screen, monitor, manager->priv->lock_active);
+	window = gs_window_new (display, monitor, manager->priv->lock_active);
 
 	gs_window_set_user_switch_enabled (window, manager->priv->user_switch_enabled);
 	gs_window_set_logout_enabled (window, manager->priv->logout_enabled);
@@ -1560,16 +1593,22 @@ static void
 on_screen_monitors_changed (GdkScreen *screen,
                             GSManager *manager)
 {
-	GSList *l;
-	int     n_monitors;
-	int     n_windows;
-	int     i;
+	GSList     *l;
+	GdkDisplay *display;
+	int         n_monitors;
+	int         n_windows;
+	int         i;
 
+	display = gdk_screen_get_display (screen);
+#if GTK_CHECK_VERSION (3, 22, 0)
+	n_monitors = gdk_display_get_n_monitors (display);
+#else
 	n_monitors = gdk_screen_get_n_monitors (screen);
+#endif
 	n_windows = g_slist_length (manager->priv->windows);
 
-	gs_debug ("Monitors changed for screen %d: num=%d",
-	          gdk_screen_get_number (screen),
+	gs_debug ("Monitors changed for display %s: num=%d",
+	          gdk_display_get_name (display),
 	          n_monitors);
 
 	if (n_monitors > n_windows)
@@ -1588,7 +1627,13 @@ on_screen_monitors_changed (GdkScreen *screen,
 		/* add more windows */
 		for (i = n_windows; i < n_monitors; i++)
 		{
-			gs_manager_create_window_for_monitor (manager, screen, i);
+#if GTK_CHECK_VERSION (3, 22, 0)
+			GdkMonitor *mon = gdk_display_get_monitor (display, i);
+			gs_manager_create_window_for_monitor (manager, mon);
+#else
+			gs_manager_create_window_for_monitor (manager,
+			                                      display, i);
+#endif
 		}
 
 		/* And put unlock dialog up where ever it's supposed to be
@@ -1604,13 +1649,23 @@ on_screen_monitors_changed (GdkScreen *screen,
 		l = manager->priv->windows;
 		while (l != NULL)
 		{
-			GdkScreen *this_screen;
-			int        this_monitor;
-			GSList    *next = l->next;
+			GdkDisplay *this_display;
+#if GTK_CHECK_VERSION (3, 22, 0)
+			GdkMonitor *this_monitor;
+#else
+			int         this_monitor;
+#endif
+			GSList     *next = l->next;
 
-			this_screen = gs_window_get_screen (GS_WINDOW (l->data));
+			this_display = gs_window_get_display (GS_WINDOW (l->data));
 			this_monitor = gs_window_get_monitor (GS_WINDOW (l->data));
-			if (this_screen == screen && this_monitor >= n_monitors)
+#if GTK_CHECK_VERSION (3, 22, 0)
+			if (this_display == display &&
+			    !GDK_IS_MONITOR (this_monitor))
+#else
+			if (this_display == display &&
+			    this_monitor >= n_monitors)
+#endif
 			{
 				manager_maybe_stop_job_for_window (manager, GS_WINDOW (l->data));
 				g_hash_table_remove (manager->priv->jobs, l->data);
@@ -1704,29 +1759,43 @@ gs_manager_finalize (GObject *object)
 }
 
 static void
-gs_manager_create_windows_for_screen (GSManager *manager,
-                                      GdkScreen *screen)
+gs_manager_create_windows_for_display (GSManager  *manager,
+                                       GdkDisplay *display)
 {
-	int       n_monitors;
-	int       i;
+#if !GTK_CHECK_VERSION (3, 22, 0)
+	GdkScreen *screen;
+#endif
+	int n_monitors;
+	int i;
 
 	g_return_if_fail (manager != NULL);
 	g_return_if_fail (GS_IS_MANAGER (manager));
-	g_return_if_fail (GDK_IS_SCREEN (screen));
+	g_return_if_fail (GDK_IS_DISPLAY (display));
 
 	g_object_ref (manager);
-	g_object_ref (screen);
+	g_object_ref (display);
 
+#if GTK_CHECK_VERSION (3, 22, 0)
+	n_monitors = gdk_display_get_n_monitors (display);
+#else
+	screen = gdk_display_get_default_screen (display);
 	n_monitors = gdk_screen_get_n_monitors (screen);
+#endif
 
-	gs_debug ("Creating %d windows for screen %d", n_monitors, gdk_screen_get_number (screen));
+	gs_debug ("Creating %d windows for display %s",
+	          n_monitors, gdk_display_get_name (display));
 
 	for (i = 0; i < n_monitors; i++)
 	{
-		gs_manager_create_window_for_monitor (manager, screen, i);
+#if GTK_CHECK_VERSION (3, 22, 0)
+		GdkMonitor *mon = gdk_display_get_monitor (display, i);
+		gs_manager_create_window_for_monitor (manager, mon);
+#else
+		gs_manager_create_window_for_monitor (manager, display, i);
+#endif
 	}
 
-	g_object_unref (screen);
+	g_object_unref (display);
 	g_object_unref (manager);
 }
 
@@ -1746,8 +1815,7 @@ gs_manager_create_windows (GSManager *manager)
 	                  G_CALLBACK (on_screen_monitors_changed),
 	                  manager);
 
-	gs_manager_create_windows_for_screen (manager,
-	                                      gdk_display_get_default_screen (display));
+	gs_manager_create_windows_for_display (manager, display);
 }
 
 GSManager *

--- a/src/gs-visual-gl.c
+++ b/src/gs-visual-gl.c
@@ -38,13 +38,14 @@
 #include "gs-debug.h"
 
 GdkVisual *
-gs_visual_gl_get_best_for_screen (GdkScreen *screen)
+gs_visual_gl_get_best_for_display (GdkDisplay *display)
 {
-	GdkVisual  *visual;
+	GdkVisual *visual;
 #ifdef HAVE_LIBGL
-	GdkDisplay *display;
-	int         screen_num;
-	int         i;
+	Display   *xdisplay;
+	GdkScreen *screen;
+	int        screen_num;
+	int        i;
 
 # define R GLX_RED_SIZE
 # define G GLX_GREEN_SIZE
@@ -72,10 +73,11 @@ gs_visual_gl_get_best_for_screen (GdkScreen *screen)
 		{ GLX_RGBA, R, 1, G, 1, B, 1, D, 1,           0 }  /* monochrome */
 	};
 
-	g_return_val_if_fail (screen != NULL, NULL);
+	g_return_val_if_fail (display != NULL, NULL);
 
-	display = gdk_screen_get_display (screen);
-	screen_num = gdk_screen_get_number (screen);
+	xdisplay = GDK_DISPLAY_XDISPLAY (display);
+	screen = gdk_display_get_default_screen (display);
+	screen_num = GDK_SCREEN_XNUMBER (screen);
 
 	gdk_error_trap_push ();
 
@@ -84,7 +86,7 @@ gs_visual_gl_get_best_for_screen (GdkScreen *screen)
 	{
 		XVisualInfo *vi;
 
-		vi = glXChooseVisual (GDK_DISPLAY_XDISPLAY (display), screen_num, attrs [i]);
+		vi = glXChooseVisual (xdisplay, screen_num, attrs [i]);
 
 		if (vi != NULL)
 		{

--- a/src/gs-visual-gl.h
+++ b/src/gs-visual-gl.h
@@ -25,7 +25,7 @@
 
 G_BEGIN_DECLS
 
-GdkVisual   *gs_visual_gl_get_best_for_screen      (GdkScreen *screen);
+GdkVisual   *gs_visual_gl_get_best_for_display (GdkDisplay *display);
 
 G_END_DECLS
 

--- a/src/gs-window.h
+++ b/src/gs-window.h
@@ -59,12 +59,16 @@ GType       gs_window_get_type           (void);
 gboolean    gs_window_is_obscured        (GSWindow  *window);
 gboolean    gs_window_is_dialog_up       (GSWindow  *window);
 
-void        gs_window_set_screen         (GSWindow  *window,
-        GdkScreen *screen);
-GdkScreen * gs_window_get_screen         (GSWindow  *window);
-void        gs_window_set_monitor        (GSWindow  *window,
-        int        monitor);
+GdkDisplay * gs_window_get_display       (GSWindow  *window);
+#if GTK_CHECK_VERSION (3, 22, 0)
+void        gs_window_set_monitor        (GSWindow   *window,
+                                          GdkMonitor *monitor);
+GdkMonitor * gs_window_get_monitor        (GSWindow  *window);
+#else
+void        gs_window_set_monitor        (GSWindow   *window,
+                                          int         monitor);
 int         gs_window_get_monitor        (GSWindow  *window);
+#endif
 
 void        gs_window_set_background_surface (GSWindow *window,
         cairo_surface_t *surface);
@@ -92,9 +96,13 @@ void        gs_window_show_message         (GSWindow   *window,
 void        gs_window_request_unlock     (GSWindow  *window);
 void        gs_window_cancel_unlock_request (GSWindow  *window);
 
-GSWindow  * gs_window_new                (GdkScreen *screen,
-        int        monitor,
-        gboolean   lock_enabled);
+GSWindow  * gs_window_new                (GdkDisplay *display,
+#if GTK_CHECK_VERSION (3, 22, 0)
+                                          GdkMonitor *monitor,
+#else
+                                          int         monitor,
+#endif
+                                          gboolean   lock_enabled);
 void        gs_window_show               (GSWindow  *window);
 void        gs_window_destroy            (GSWindow  *window);
 GdkWindow * gs_window_get_gdk_window     (GSWindow  *window);

--- a/src/mate-screensaver-gl-helper.c
+++ b/src/mate-screensaver-gl-helper.c
@@ -35,7 +35,6 @@ main (int    argc,
       char **argv)
 {
 	GdkDisplay     *display;
-	GdkScreen      *screen;
 	GdkVisual      *visual;
 	Visual         *xvisual;
 	GError         *error = NULL;
@@ -64,8 +63,7 @@ main (int    argc,
 	}
 
 	display = gdk_display_get_default ();
-	screen = gdk_display_get_default_screen (display);
-	visual = gs_visual_gl_get_best_for_screen (screen);
+	visual = gs_visual_gl_get_best_for_display (display);
 
 	if (visual != NULL)
 	{

--- a/src/test-window.c
+++ b/src/test-window.c
@@ -60,7 +60,7 @@ window_show_cb (GSWindow  *window,
 	/* Grab keyboard so dialog can be used */
 	gs_grab_move_to_window (grab,
 	                        gs_window_get_gdk_window (window),
-	                        gs_window_get_screen (window),
+	                        gs_window_get_display (window),
 	                        FALSE);
 
 }
@@ -120,18 +120,28 @@ connect_window_signals (GSWindow *window)
 static void
 test_window (void)
 {
-	GSWindow  *window;
-	gboolean   lock_active;
-	gboolean   user_switch_enabled;
-	GdkScreen *screen;
-	int        monitor;
+	GSWindow   *window;
+	gboolean    lock_active;
+	gboolean    user_switch_enabled;
+	GdkDisplay *display;
+#if GTK_CHECK_VERSION (3, 22, 0)
+	GdkMonitor *monitor;
+#else
+	GdkScreen  *screen;
+	int         monitor;
+#endif
 
 	lock_active = TRUE;
 	user_switch_enabled = TRUE;
-	screen = gdk_screen_get_default ();
-	monitor = 0;
+	display = gdk_display_get_default ();
+#if GTK_CHECK_VERSION (3, 22, 0)
+	monitor = gdk_display_get_primary_monitor (display);
+#else
+	screen = gdk_display_get_default_screen (display);
+	monitor = gdk_screen_get_primary_monitor (screen);
+#endif
 
-	window = gs_window_new (screen, monitor, lock_active);
+	window = gs_window_new (display, monitor, lock_active);
 
 	gs_window_set_user_switch_enabled (window, user_switch_enabled);
 


### PR DESCRIPTION
GTK+ 3.22 has broken them completely, and in mate-screensaver there aren't really a need in them at all, in any GTK+ version.
This fixes #98 and #103.