### PR TITLE
1.16: Avoid deprecated gdk_window_set_background functions

### DIFF
--- a/data/mate-screensaver-preferences.ui
+++ b/data/mate-screensaver-preferences.ui
@@ -129,6 +129,7 @@
         <child>
           <object class="GtkDrawingArea" id="fullscreen_preview_area">
             <property name="visible">True</property>
+            <property name="app_paintable">True</property>
             <property name="can_focus">False</property>
           </object>
           <packing>
@@ -302,6 +303,7 @@
                             </child>
                             <child>
                               <object class="GtkDrawingArea" id="preview_area">
+                                <property name="app_paintable">True</property>
                                 <property name="can_focus">False</property>
                               </object>
                               <packing>

--- a/savers/floaters.c
+++ b/savers/floaters.c
@@ -1103,8 +1103,9 @@ screen_saver_update_state (ScreenSaver *screen_saver,
 
 		screen_saver_floater_update_state (screen_saver, floater, time);
 
-		if (gtk_widget_get_realized (screen_saver->drawing_area)
-		        && (floater->bounds.width > 0) && (floater->bounds.height > 0))
+		if (screen_saver->drawing_area != NULL &&
+		    gtk_widget_get_realized (screen_saver->drawing_area) &&
+		    (floater->bounds.width > 0) && (floater->bounds.height > 0))
 		{
 			gint size;
 			size = CLAMP ((int) (FLOATER_MAX_SIZE * floater->scale),

--- a/savers/gs-theme-engine.c
+++ b/savers/gs-theme-engine.c
@@ -107,56 +107,28 @@ gs_theme_engine_get_property (GObject            *object,
 	}
 }
 
-static void
-gs_theme_engine_clear (GtkWidget *widget)
-{
-#if GTK_CHECK_VERSION (3, 0, 0)
-	GdkRGBA color = { 0.0, 0.0, 0.0, 1.0 };
-	GtkStateFlags state;
-#else
-	GdkColor     color = { 0, 0x0000, 0x0000, 0x0000 };
-	GdkColormap  *colormap;
-	GtkStyle     *style;
-	GtkStateType state;
-#endif
-
-	g_return_if_fail (GS_IS_THEME_ENGINE (widget));
-
-	if (! gtk_widget_get_visible (widget))
-	{
-		return;
-	}
-
-#if GTK_CHECK_VERSION (3, 0, 0)
-	state = gtk_widget_get_state_flags (widget);
-	gtk_widget_override_background_color (widget, state, &color);
-	gdk_window_set_background_rgba (gtk_widget_get_window (widget), &color);
-#else
-	style = gtk_widget_get_style (widget);
-	state = (GtkStateType) 0;
-	while (state < (GtkStateType) G_N_ELEMENTS (style->bg))
-	{
-		gtk_widget_modify_bg (widget, state, &color);
-		state++;
-	}
-
-	colormap = gdk_drawable_get_colormap (gtk_widget_get_window (widget));
-	gdk_colormap_alloc_color (colormap, &color, FALSE, TRUE);
-	gdk_window_set_background (gtk_widget_get_window (widget), &color);
-	gdk_window_clear (gtk_widget_get_window (widget));
-#endif
-	gdk_flush ();
-}
-
 static gboolean
-gs_theme_engine_real_map_event (GtkWidget   *widget,
-                                GdkEventAny *event)
+#if GTK_CHECK_VERSION (3, 0, 0)
+gs_theme_engine_real_draw (GtkWidget *widget,
+                           cairo_t   *cr)
+#else
+gs_theme_engine_real_expose_event (GtkWidget      *widget,
+                                   GdkEventExpose *event)
+#endif
 {
-	gboolean handled = FALSE;
+#if !GTK_CHECK_VERSION (3, 0, 0)
+	GdkWindow *window = gtk_widget_get_window (widget);
+	cairo_t *cr = gdk_cairo_create (window);
 
-	gs_theme_engine_clear (widget);
+#endif
+	cairo_set_operator (cr, CAIRO_OPERATOR_OVER);
+	cairo_set_source_rgb (cr, 0, 0, 0);
+	cairo_paint (cr);
 
-	return handled;
+#if !GTK_CHECK_VERSION (3, 0, 0)
+	cairo_destroy (cr);
+#endif
+	return FALSE;
 }
 
 static void
@@ -171,7 +143,11 @@ gs_theme_engine_class_init (GSThemeEngineClass *klass)
 	object_class->get_property = gs_theme_engine_get_property;
 	object_class->set_property = gs_theme_engine_set_property;
 
-	widget_class->map_event = gs_theme_engine_real_map_event;
+#if GTK_CHECK_VERSION (3, 0, 0)
+	widget_class->draw = gs_theme_engine_real_draw;
+#else
+	widget_class->expose_event = gs_theme_engine_real_expose_event;
+#endif
 
 	g_type_class_add_private (klass, sizeof (GSThemeEnginePrivate));
 }

--- a/src/gs-window.h
+++ b/src/gs-window.h
@@ -66,13 +66,8 @@ void        gs_window_set_monitor        (GSWindow  *window,
         int        monitor);
 int         gs_window_get_monitor        (GSWindow  *window);
 
-#if GTK_CHECK_VERSION (3, 0, 0)
 void        gs_window_set_background_surface (GSWindow *window,
-        cairo_surface_t *surface);
-#else
-void        gs_window_set_background_pixmap (GSWindow  *window,
-        GdkPixmap *pixmap);
-#endif
+                                              cairo_surface_t *surface);
 void        gs_window_set_lock_enabled   (GSWindow  *window,
         gboolean   lock_enabled);
 void        gs_window_set_logout_enabled (GSWindow  *window,

--- a/src/mate-screensaver-preferences.c
+++ b/src/mate-screensaver-preferences.c
@@ -1149,10 +1149,20 @@ fullscreen_preview_previous_cb (GtkWidget *fullscreen_preview_window,
 {
 	GtkWidget        *treeview;
 	GtkTreeSelection *selection;
+#if !GTK_CHECK_VERSION (3, 0, 0)
+	GtkWidget        *fullscreen_preview_area;
+#endif
 
 	treeview = GTK_WIDGET (gtk_builder_get_object (builder, "savers_treeview"));
 	selection = gtk_tree_view_get_selection (GTK_TREE_VIEW (treeview));
 	tree_selection_previous (selection);
+#if !GTK_CHECK_VERSION (3, 0, 0)
+
+	fullscreen_preview_area =
+	  GTK_WIDGET (gtk_builder_get_object (builder,
+	                                      "fullscreen_preview_area"));
+	gtk_widget_queue_draw (fullscreen_preview_area);
+#endif
 }
 
 static void
@@ -1161,10 +1171,20 @@ fullscreen_preview_next_cb (GtkWidget *fullscreen_preview_window,
 {
 	GtkWidget        *treeview;
 	GtkTreeSelection *selection;
+#if !GTK_CHECK_VERSION (3, 0, 0)
+	GtkWidget        *fullscreen_preview_area;
+#endif
 
 	treeview = GTK_WIDGET (gtk_builder_get_object (builder, "savers_treeview"));
 	selection = gtk_tree_view_get_selection (GTK_TREE_VIEW (treeview));
 	tree_selection_next (selection);
+#if !GTK_CHECK_VERSION (3, 0, 0)
+
+	fullscreen_preview_area =
+	  GTK_WIDGET (gtk_builder_get_object (builder,
+	                                      "fullscreen_preview_area"));
+	gtk_widget_queue_draw (fullscreen_preview_area);
+#endif
 }
 
 static void


### PR DESCRIPTION
GTK+ 3.22 has broken them completely, and in mate-screensaver there aren't really a need in them at all, in any GTK+ version.
Additionally this significantly reduces the gap between the code for GTK+2 and GTK+3.