### PR TITLE
Change shake times to even number, so the dialog can return to its original position.

### DIFF
--- a/src/gs-window-x11.c
+++ b/src/gs-window-x11.c
@@ -1496,7 +1496,7 @@ shake_dialog (GSWindow *window)
 
 	window->priv->dialog_shake_in_progress = TRUE;
 
-	for (i = 0; i < 9; i++)
+	for (i = 0; i < 8; i++)
 	{
 		if (i % 2 == 0)
 		{


### PR DESCRIPTION
Hi, I found a bug in `shake_dialog` function.

When the password is wrong, the dialog will shake several times to indicate that result. However, there is a bug in `shake_dialog` function.

Variable `i` will increase from `0` to `8` and this `for loop` will be executed **odd times**, so the dialog will stay on the right of its original position.

I have changed the max value of `i` to `8` and it works properly!