### PR TITLE
Switch to GdkSeat for GTK+ 3.20 and newer

### DIFF
--- a/src/gs-grab.h
+++ b/src/gs-grab.h
@@ -53,26 +53,29 @@ GType     gs_grab_get_type         (void);
 
 GSGrab  * gs_grab_new              (void);
 
-void      gs_grab_release          (GSGrab    *grab);
-gboolean  gs_grab_release_mouse    (GSGrab    *grab);
+void      gs_grab_release          (GSGrab    *grab,
+                                    gboolean   flush);
 
 gboolean  gs_grab_grab_window      (GSGrab     *grab,
                                     GdkWindow  *window,
                                     GdkDisplay *display,
+                                    gboolean    no_pointer_grab,
                                     gboolean    hide_cursor);
 
 gboolean  gs_grab_grab_root        (GSGrab    *grab,
+                                    gboolean   no_pointer_grab,
                                     gboolean   hide_cursor);
 gboolean  gs_grab_grab_offscreen   (GSGrab    *grab,
+                                    gboolean   no_pointer_grab,
                                     gboolean   hide_cursor);
 
 void      gs_grab_move_to_window   (GSGrab     *grab,
                                     GdkWindow  *window,
                                     GdkDisplay *display,
+                                    gboolean    no_pointer_grab,
                                     gboolean    hide_cursor);
 
-void      gs_grab_mouse_reset      (GSGrab    *grab);
-void      gs_grab_keyboard_reset   (GSGrab    *grab);
+void      gs_grab_reset            (GSGrab     *grab);
 
 G_END_DECLS
 

--- a/src/gs-monitor.c
+++ b/src/gs-monitor.c
@@ -102,7 +102,7 @@ static gboolean release_grab_timeout(GSMonitor* monitor)
 
 	if (! manager_active)
 	{
-		gs_grab_release(monitor->priv->grab);
+		gs_grab_release(monitor->priv->grab, TRUE);
 	}
 
 	monitor->priv->release_grab_id = 0;
@@ -128,7 +128,7 @@ static gboolean watcher_idle_notice_cb(GSWatcher* watcher, gboolean in_effect, G
 		if (activation_enabled && ! inhibited)
 		{
 			/* start slow fade */
-			if (gs_grab_grab_offscreen(monitor->priv->grab, FALSE))
+			if (gs_grab_grab_offscreen(monitor->priv->grab, FALSE, FALSE))
 			{
 				gs_fade_async(monitor->priv->fade, FADE_TIMEOUT, NULL, NULL);
 			}

--- a/src/test-window.c
+++ b/src/test-window.c
@@ -57,12 +57,11 @@ static void
 window_show_cb (GSWindow  *window,
                 gpointer   data)
 {
-	/* Grab keyboard so dialog can be used */
+	/* move devices grab so that dialog can be used */
 	gs_grab_move_to_window (grab,
 	                        gs_window_get_gdk_window (window),
 	                        gs_window_get_display (window),
-	                        FALSE);
-
+	                        TRUE, FALSE);
 }
 
 static gboolean
@@ -92,7 +91,7 @@ window_destroyed_cb (GtkWindow *window,
                      gpointer   data)
 {
 	disconnect_window_signals (GS_WINDOW (window));
-	gs_grab_release (grab);
+	gs_grab_release (grab, TRUE);
 	gtk_main_quit ();
 }
 


### PR DESCRIPTION
```gdk_keyboard_grab``` and ```gdk_pointer_grab``` are removed from GTK+ 4 making this an important change for the future.
Yet at the same time I can't be 100% confident because I'm touching (a lot) a very important part of screenlocking potentionally creating a "security issue".