### PR TITLE
Implement OpenBSD authentication using bsd_auth(3).

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -532,6 +532,44 @@ if test "x$have_libgl" = "xyes"; then
 fi
 
 dnl ---------------------------------------------------------------------------
+dnl - Check for bsd_auth(3) (OpenBSD)
+dnl ---------------------------------------------------------------------------
+have_bsdauth=no
+with_bsdauth_req=unspecified
+NEED_SETUID=no
+
+case "$host" in
+  *-openbsd*)
+    with_bsdauth=yes
+    AUTH_SCHEME=bsdauth
+    NEED_SETUID=no
+    if test "x$enable_locking" = "xyes"; then
+      with_bsdauth_req=yes
+      NEED_SETUID=yes
+    fi
+esac
+
+if test "$with_bsdauth" = yes ; then
+  AC_CACHE_CHECK([for BSD Authentication], ac_cv_bsdauth,
+    [AC_TRY_X_COMPILE([#include <stdlib.h>
+                       #include <unistd.h>
+                       #include <sys/types.h>
+                       #include <bsd_auth.h>],
+      [int ok = auth_userokay("x", 0, "x", "x");],
+      [ac_cv_bsdauth=yes],
+      [ac_cv_bsdauth=no])])
+  if test "$ac_cv_bsdauth" = yes; then
+    have_bsdauth=yes
+  fi
+fi
+
+if test "$have_bsdauth" = yes; then
+  AC_DEFINE(HAVE_BSDAUTH, 1, [Define to 1 if using bsd_auth(3) authentication])
+fi
+
+AC_SUBST(NEED_SETUID)
+
+dnl ---------------------------------------------------------------------------
 dnl - Check for PAM
 dnl ---------------------------------------------------------------------------
 
@@ -540,7 +578,7 @@ AC_ARG_ENABLE(pam, AC_HELP_STRING([--enable-pam],
                    [Enable PAM support @<:@default=auto@:>@],
                    ),,enable_pam=auto)
 
-if test "x$enable_locking" = "xyes" -a  "x$enable_pam" != "xno"; then
+if test "x$enable_locking" = "xyes" -a "x$enable_pam" != "xno" -a "x$have_bsdauth" = "xno"; then
 AC_CHECK_LIB(pam, pam_start, have_pam=yes)
 fi
 if test "x$have_pam" = "xyes"; then
@@ -823,7 +861,7 @@ dnl  Authentication scheme
 dnl ---------------------------------------------------------------------------
 
 AC_ARG_ENABLE(authentication-scheme,
-  [  --enable-authentication-scheme=[auto/pam/helper/pwent]  Choose a specific
+  [  --enable-authentication-scheme=[auto/pam/helper/pwent/bsdauth]  Choose a specific
                           authentication scheme [default=auto]],,
   enable_authentication_scheme=auto)
 
@@ -835,6 +873,9 @@ fi
 if test x$enable_authentication_scheme = xhelper -a x$have_passwd_helper = xno ; then
 	AC_MSG_ERROR(Password helper support requested but not available)
 fi
+if test x$enable_authentication_scheme = xbsdauth -a x$have_bsdauth = xno ; then
+	AC_MSG_ERROR(bsd_auth(3) support requested but not available)
+fi
 
 if test x$enable_authentication_scheme = xpam ; then
         AUTH_SCHEME="pam"
@@ -842,11 +883,15 @@ elif test x$enable_authentication_scheme = xhelper ; then
         AUTH_SCHEME="helper"
 elif test x$enable_authentication_scheme = xpwent ; then
         AUTH_SCHEME="pwent"
+elif test x$enable_authentication_scheme = xbsdauth ; then
+	AUTH_SCHEME="bsdauth"
 elif test x$enable_authentication_scheme = xauto ; then
 	if test x$have_pam != xno ; then
 		AUTH_SCHEME="pam"
 	elif test x$have_passwd_helper != xno ; then
 		AUTH_SCHEME="helper"
+	elif test x$have_bsdauth != xno ; then
+		AUTH_SCHEME="bsdauth"
 	else
 		AUTH_SCHEME="pwent"
         fi
@@ -1127,6 +1172,7 @@ echo "
         ConsoleKit support:       ${use_console_kit}
         libnotify support:        ${have_libnotify}
         PAM support:              ${have_pam}
+        bsd_auth(3) support:      ${have_bsdauth}
         Have shadow passwords:    ${have_shadow}
         Have adjunct shadow:      ${have_shadow_adjunct}
         Have enhanced shadow:     ${have_shadow_enhanced}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -256,9 +256,13 @@ install-exec-hook:
 	@if [ "x@NEED_SETUID@" = "xyes" ]; then \
 	    echo "***" ; \
 	    echo "***  Warning: mate-screensaver has been compiled with support for" ; \
-	    echo "***           shadow passwords.  If your system actually uses shadow" ; \
-	    echo "***           passwords then it must be installed as a setuid root" ; \
-	    echo "***           program in order for locking to work.  To do this, you" ; \
+	    if [ "x@AUTH_SCHEME@" = "xbsdauth" ]; then \
+		echo "***           bsd_auth(3) and must be installed as a setuid root" ; \
+	    else \
+	        echo "***           shadow passwords. If your system actually uses shadow" ; \
+	        echo "***           passwords then it must be installed as a setuid root" ; \
+	    fi; \
+	    echo "***           program in order for locking to work. To do this, you" ; \
 	    echo "***           must run:" ; \
 	    echo "***" ; \
 	    echo "***           chown root $(DESTDIR)$(libexecdir)/mate-screensaver-dialog" ; \

--- a/src/gs-auth-bsdauth.c
+++ b/src/gs-auth-bsdauth.c
@@ -1,0 +1,103 @@
+/*
+ * gs-auth-bsdauth.c --- verifying typed passwords with bsd_auth(3)
+ *
+ * Copyright (c) 1993-1998 Jamie Zawinski <jwz@jwz.org>
+ * Copyright (C) 2006 William Jon McCann <mccann@jhu.edu>
+ * Copyright (c) 2009 Antoine Jacoutot <ajacoutot@openbsd.org>
+ * Copyright (c) 2017 Robert Nagy <robert@openbsd.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "config.h"
+
+#include <stdio.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <string.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#include <pwd.h>
+#include <sys/types.h>
+
+#include <login_cap.h>
+#include <bsd_auth.h>
+
+#include "gs-auth.h"
+#include "subprocs.h"
+
+static gboolean verbose_enabled = FALSE;
+
+GQuark
+gs_auth_error_quark (void)
+{
+	static GQuark quark = 0;
+	if (! quark) {
+		quark = g_quark_from_static_string ("gs_auth_error");
+	}
+
+	return quark;
+}
+
+void
+gs_auth_set_verbose (gboolean enabled)
+{
+	verbose_enabled = enabled;
+}
+
+gboolean
+gs_auth_get_verbose (void)
+{
+	return verbose_enabled;
+}
+
+gboolean
+gs_auth_verify_user (const char       *username,
+                     const char       *display,
+                     GSAuthMessageFunc func,
+                     gpointer          data,
+                     GError          **error)
+{
+	int res;
+	char *password;
+
+	/* ask for the password for user */
+	if (func != NULL) {
+		func (GS_AUTH_MESSAGE_PROMPT_ECHO_OFF,
+		    "Password: ",
+		    &password,
+		    data);
+	}
+
+	if (password == NULL) {
+		return FALSE;
+	}
+
+	/* authenticate */
+	res = auth_userokay((char *)username, NULL, "auth-mate-screensaver", password);
+
+	return res;
+}
+
+gboolean
+gs_auth_init (void)
+{
+	return TRUE;
+}
+
+gboolean
+gs_auth_priv_init (void)
+{
+	return TRUE;
+}

--- a/src/gs-auth-pwent.c
+++ b/src/gs-auth-pwent.c
@@ -171,10 +171,10 @@ get_encrypted_passwd (const char *user)
 		}
 	}
 
-#ifndef HAVE_PAM
-	/* We only issue this warning if not compiled with support for PAM.
-	   If we're using PAM, it's not unheard of that normal pwent passwords
-	   would be unavailable. */
+#if !defined(HAVE_PAM) && !defined(HAVE_BSDAUTH)
+	/* We only issue this warning if not compiled with support for PAM,
+	   or bsd_auth(3). If we're using PAM, it's not unheard of that
+	   normal pwent passwords would be unavailable. */
 
 	if (!result)
 	{

--- a/src/setuid.c
+++ b/src/setuid.c
@@ -209,6 +209,15 @@ hack_uid (char **nolock_reason,
 
 		if (uid != euid || gid != egid)
 		{
+#ifdef HAVE_BSDAUTH /* we need to setgid auth to run the bsd_auth(3) login_* helpers */
+			struct group *authg = getgrnam("auth");
+			if (!authg || !authg->gr_name || !*authg->gr_name) {
+				reason = g_strdup ("no such group as \"auth\" for bsdauth.");
+				ret = FALSE;
+				goto out;
+			}
+			gid = authg->gr_gid;
+#endif /* !HAVE_BSDAUTH */
 			if (! set_ids_by_number (uid, gid, uid_message))
 			{
 				reason = g_strdup ("unable to discard privileges.");


### PR DESCRIPTION
OpenBSD does not have nor use pam(8) for password authentication but
instead uses bsd_auth(3): add a bsd_auth authentication scheme to
make locking possible.
This has been a part of gnome-screensaver already but was probably
removed at one point. This is mostly identical to that code, with some
minor modifications.