### PR TITLE
 Fix: idle slider display in all languages

### DIFF
--- a/src/mate-screensaver-preferences.c
+++ b/src/mate-screensaver-preferences.c
@@ -942,7 +942,7 @@ time_to_string_text (long time)
 	char *secs, *mins, *hours, *string;
 	int   sec, min, hour;
 
-	int   inc_len, len_hour, len_minutes;
+	int   inc_len, len_minutes;
 
 	sec = time % 60;
 	time = time - sec;
@@ -965,9 +965,6 @@ time_to_string_text (long time)
 	                  g_strdup_printf (ngettext ("%d minute",
 	                                             "%d minutes", 59), 59))) - 1;
 
-	len_hour = strlen (g_strdup_printf (ngettext ("%d hour",
-	                                              "%d hours", 1), 1));
-
 	len_minutes = 0;
 
 	for (int n = 2; n < 60; n++)
@@ -989,6 +986,15 @@ time_to_string_text (long time)
 	                                                                                         "%d minutes", n), n), NULL)) - 3;
 		}
 	}
+
+	if ((strlen (g_str_to_ascii (g_strdup_printf (ngettext ("%d minute",
+	                                                        "%d minutes", 1), 1), NULL)) - 2) > len_minutes)
+
+		len_minutes = strlen (g_str_to_ascii (g_strdup_printf (ngettext ("%d minute",
+	                                                                         "%d minutes", 1), 1), NULL)) - 2;
+
+	if (len_minutes < 1)
+		len_minutes = 1;
 
 	if (hour > 0)
 	{
@@ -1023,7 +1029,7 @@ time_to_string_text (long time)
 			if (min < 10)
 			{
 				if (min == 1)
-					while (strlen (string) != (2 * len_hour + inc_len - 4))
+					while (strlen (string) != (len_minutes + inc_len + 3))
 					{
 						if (strlen (string) % 2 == 0)
 							string = g_strconcat (string, " ", NULL);


### PR DESCRIPTION
I began the work in https://github.com/mate-desktop/mate-screensaver/pull/138 but some languages didn't work

This is the fix to work in all languages

It works here with:

```
  am_ET.UTF-8... done
  ar_IQ.UTF-8... done
  ar_SA.UTF-8... done
  as_IN.UTF-8... done
  ast_ES.UTF-8... done
  be_BY.UTF-8... done
  bg_BG.UTF-8... done
  bn_BD.UTF-8... done
  bn_IN.UTF-8... done
  br_FR.UTF-8... done
  bs_BA.UTF-8... done
  ca_ES.UTF-8... done
  ca_ES.UTF-8@valencia... done
  cmn_TW.UTF-8... done
  crh_UA.UTF-8... done
  cs_CZ.UTF-8... done
  cy_GB.UTF-8... done
  da_DK.UTF-8... done
  de_DE.UTF-8... done
  dz_BT.UTF-8... done
  el_GR.UTF-8... done
  en_AU.UTF-8... done
  en_CA.UTF-8... done
  en_GB.UTF-8... done
  es_AR.UTF-8... done
  es_CO.UTF-8... done
  es_ES.UTF-8... done
  et_EE.UTF-8... done
  eu_ES.UTF-8... done
  fa_IR.UTF-8... done
  fi_FI.UTF-8... done
  fr_CA.UTF-8... done
  fr_CH.UTF-8... done
  fr_FR.UTF-8... done
  ga_IE.UTF-8... done
  gl_ES.UTF-8... done
  gu_IN.UTF-8... done
  he_IL.UTF-8... done
  hi_IN.UTF-8... done
  hr_HR.UTF-8... done
  hu_HU.UTF-8... done
  hy_AM.UTF-8... done
  id_ID.UTF-8... done
  is_IS.UTF-8... done
  it_IT.UTF-8... done
  ja_JP.UTF-8... done
  ka_GE.UTF-8... done
  kk_KZ.UTF-8... done
  kn_IN.UTF-8... done
  ko_KR.UTF-8... done
  ku_TR.UTF-8... done
  ky_KG.UTF-8... done
  lt_LT.UTF-8... done
  lv_LV.UTF-8... done
  mai_IN.UTF-8... done
  mg_MG.UTF-8... done
  mk_MK.UTF-8... done
  ml_IN.UTF-8... done
  mn_MN.UTF-8... done
  mr_IN.UTF-8... done
  ms_MY.UTF-8... done
  nb_NO.UTF-8... done
  nds_DE.UTF-8... done
  ne_NP.UTF-8... done
  nl_AW.UTF-8... done
  nn_NO.UTF-8... done
  oc_FR.UTF-8... done
  or_IN.UTF-8... done
  pa_PK.UTF-8... done
  pl_PL.UTF-8... done
  ps_AF.UTF-8... done
  pt_BR.UTF-8... done
  pt_PT.UTF-8... done
  ro_RO.UTF-8... done
  ru_RU.UTF-8... done
  si_LK.UTF-8... done
  sk_SK.UTF-8... done
  sl_SI.UTF-8... done
  sq_MK.UTF-8... done
  sr_RS.UTF-8... done
  sr_RS.UTF-8@latin... done
  sv_FI.UTF-8... done
  ta_IN.UTF-8... done
  te_IN.UTF-8... done
  th_TH.UTF-8... done
  tr_TR.UTF-8... done
  uk_UA.UTF-8... done
  ur_PK.UTF-8... done
  uz_UZ.UTF-8... done
  vi_VN.UTF-8... done
  zh_CN.UTF-8... done
  zh_HK.UTF-8... done
  zh_TW.UTF-8... done
```