### PR TITLE
WidthOfScreen and HeightOfScreen implementation

### DIFF
--- a/src/gs-manager.c
+++ b/src/gs-manager.c
@@ -1320,10 +1320,8 @@ apply_background_to_window (GSManager *manager,
 
 	display = gs_window_get_display (window);
 	screen = gdk_display_get_default_screen (display);
-
-	gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
-				 &width, &height);
-
+	width = WidthOfScreen (gdk_x11_screen_get_xscreen (screen));
+	height = HeightOfScreen (gdk_x11_screen_get_xscreen (screen));
 	gs_debug ("Creating background w:%d h:%d", width, height);
 	surface = mate_bg_create_surface (manager->priv->bg,
 	                                  gs_window_get_gdk_window (window),

--- a/src/gs-window-x11.c
+++ b/src/gs-window-x11.c
@@ -1272,12 +1272,8 @@ create_keyboard_socket (GSWindow *window,
                         guint32   id)
 {
 	int height;
-	int sc_height;
 
-	gdk_window_get_geometry (gdk_screen_get_root_window (gtk_widget_get_screen (GTK_WIDGET (window))),
-				 NULL, NULL, NULL, &sc_height);
-
-	height = sc_height / 4;
+	height = (HeightOfScreen (gdk_x11_screen_get_xscreen (gtk_widget_get_screen (GTK_WIDGET (window))))) / 4;
 
 	window->priv->keyboard_socket = gtk_socket_new ();
 	gtk_widget_set_size_request (window->priv->keyboard_socket, -1, height);
@@ -2166,17 +2162,12 @@ gs_window_real_motion_notify_event (GtkWidget      *widget,
 	gdouble     min_percentage = 0.1;
 	GdkDisplay *display;
 	GdkScreen  *screen;
-	gint        sc_width;
 
 	window = GS_WINDOW (widget);
 
 	display = gs_window_get_display (window);
 	screen = gdk_display_get_default_screen (display);
-
-	gdk_window_get_geometry (gdk_screen_get_root_window (screen), NULL, NULL,
-				 &sc_width, NULL);
-
-	min_distance = sc_width * min_percentage;
+	min_distance = WidthOfScreen (gdk_x11_screen_get_xscreen (screen)) * min_percentage;
 
 	/* if the last position was not set then don't detect motion */
 	if (window->priv->last_x < 0 || window->priv->last_y < 0)

--- a/src/mate-screensaver-preferences.c
+++ b/src/mate-screensaver-preferences.c
@@ -1284,13 +1284,9 @@ constrain_list_size (GtkWidget      *widget,
 {
 	GtkRequisition req;
 	int            max_height;
-	int            sc_height;
 
 	/* constrain height to be the tree height up to a max */
-	gdk_window_get_geometry (gdk_screen_get_root_window (gtk_widget_get_screen (widget)),
-				 NULL, NULL, NULL, &sc_height);
-
-	max_height = sc_height / 4;
+	max_height = (HeightOfScreen (gdk_x11_screen_get_xscreen (gtk_widget_get_screen (widget)))) / 4;
 
 	gtk_widget_get_preferred_size (to_size, &req, NULL);
 	allocation->height = MIN (req.height, max_height);


### PR DESCRIPTION
This commit reverts:

https://github.com/mate-desktop/mate-screensaver/commit/816394c1a6ce9968dba3e1b0ecc884c8ccca4d43

And it applies an alternative to fix the deprecated functions:

gdk_screen_get_width
gdk_screen_get_height