### PR TITLE
lock-plug: Only scale lock-screen widgets on older versions of GTK

### DIFF
--- a/src/gs-lock-plug.c
+++ b/src/gs-lock-plug.c
@@ -976,6 +976,7 @@ set_face_image (GSLockPlug *plug)
 	return TRUE;
 }
 
+#if !GTK_CHECK_VERSION (3, 23, 0)
 static void
 gs_lock_plug_get_preferred_width (GtkWidget *widget, gint *minimum_width, gint *natural_width)
 {
@@ -999,6 +1000,7 @@ gs_lock_plug_get_preferred_height_for_width (GtkWidget *widget, gint width, gint
     *minimum_height /= scale;
     *natural_height /= scale;
 }
+#endif
 
 static void
 gs_lock_plug_show (GtkWidget *widget)
@@ -1274,8 +1276,10 @@ gs_lock_plug_class_init (GSLockPlugClass *klass)
 	widget_class->style_set                      = gs_lock_plug_style_set;
 	widget_class->show                           = gs_lock_plug_show;
 	widget_class->hide                           = gs_lock_plug_hide;
+#if !GTK_CHECK_VERSION (3, 23, 0)
 	widget_class->get_preferred_width            = gs_lock_plug_get_preferred_width;
 	widget_class->get_preferred_height_for_width = gs_lock_plug_get_preferred_height_for_width;
+#endif
 
 	klass->close = gs_lock_plug_close;
 


### PR DESCRIPTION
This fixes an issue where the lock screen widgets look wrong on GTK+ >= 3.23