### PR TITLE
gs-manager.c: add missing debug information

### DIFF
--- a/src/gs-manager.c
+++ b/src/gs-manager.c
@@ -1539,8 +1539,8 @@ gs_manager_create_window_for_monitor (GSManager  *manager,
 	display = gdk_monitor_get_display (monitor);
 	gdk_monitor_get_geometry (monitor, &rect);
 
-	gs_debug ("Creating a window for the monitor [%d,%d] (%dx%d)",
-	          monitor, rect.x, rect.y, rect.width, rect.height);
+	gs_debug ("Creating a window [%d,%d] (%dx%d)",
+	          rect.x, rect.y, rect.width, rect.height);
 
 	window = gs_window_new (display, monitor, manager->priv->lock_active);
 

--- a/src/gs-window-x11.c
+++ b/src/gs-window-x11.c
@@ -387,8 +387,7 @@ gs_window_move_resize_window (GSWindow *window,
 
 	g_assert (gtk_widget_get_realized (widget));
 
-	gs_debug ("Move and/or resize window on monitor %d: x=%d y=%d w=%d h=%d",
-	          window->priv->monitor,
+	gs_debug ("Move and/or resize window: x=%d y=%d w=%d h=%d",
 	          window->priv->geometry.x,
 	          window->priv->geometry.y,
 	          window->priv->geometry.width,


### PR DESCRIPTION
Print monitor in right place:
https://github.com/mate-desktop/mate-screensaver/blob/ef8f73d6f81ac3d841bf136960adf523204412ea/src/gs-manager.c#L1542-L1543
Please review and test:) @sc0w @raveit65 