### PR TITLE
fade: fix fade computation math

### DIFF
--- a/src/gs-fade.c
+++ b/src/gs-fade.c
@@ -755,7 +755,7 @@ gs_fade_start (GSFade *fade,
 	{
 		guint num_steps;
 
-		num_steps = (fade->priv->timeout / 1000) * steps_per_sec;
+		num_steps = (fade->priv->timeout / 1000.0) * steps_per_sec;
 		msecs_per_step = 1000 / steps_per_sec;
 		fade->priv->alpha_per_iter = 1.0 / (gdouble)num_steps;
 


### PR DESCRIPTION
commit https://github.com/mate-desktop/mate-screensaver/commit/599bc81
changed the fade time out to be less than a 1000ms.  Unfortunately, this broke the fade because the
math for computing the number of fade steps used integer arithmetic,
and performed a division by a 1000.

https://bugzilla.gnome.org/show_bug.cgi?id=672583

origin commit:
https://gitlab.gnome.org/GNOME/gnome-screensaver/commit/7e2085a