### PR TITLE
mate-screensaver-command: Support unlocking (--unlock) the screensave…

### DIFF
--- a/data/mate-screensaver-command.1
+++ b/data/mate-screensaver-command.1
@@ -35,6 +35,9 @@ Query the length of time the screensaver has been active
 .B \-l, \-\-lock
 Tells the running screensaver process to lock the screen immediately
 .TP
+.B \-u, \-\-unlock
+Tells the running screensaver process to unlock the screen immediately
+.TP
 .B \-c, \-\-cycle
 If the screensaver is active then switch to another graphics demo
 .TP

--- a/doc/dbus-interface.xml
+++ b/doc/dbus-interface.xml
@@ -52,6 +52,15 @@
       </para>
     </sect2>
 
+    <sect2 id="gs-method-Unlock">
+      <title>
+        <literal>Unlock</literal>
+      </title>
+      <para>
+        Request that the screen be unlocked.
+      </para>
+    </sect2>
+
     <sect2 id="gs-method-Cycle">
       <title>
         <literal>Cycle</literal>

--- a/src/gs-listener-dbus.c
+++ b/src/gs-listener-dbus.c
@@ -1373,6 +1373,8 @@ do_introspect (DBusConnection *connection,
 	                       "  <interface name=\"org.mate.ScreenSaver\">\n"
 	                       "    <method name=\"Lock\">\n"
 	                       "    </method>\n"
+	                       "    <method name=\"Unlock\">\n"
+	                       "    </method>\n"
 	                       "    <method name=\"Cycle\">\n"
 	                       "    </method>\n"
 	                       "    <method name=\"SimulateUserActivity\">\n"
@@ -1463,6 +1465,11 @@ listener_dbus_handle_session_message (DBusConnection *connection,
 	if (dbus_message_is_method_call (message, GS_LISTENER_SERVICE, "Lock"))
 	{
 		g_signal_emit (listener, signals [LOCK], 0);
+		return DBUS_HANDLER_RESULT_HANDLED;
+	}
+	if (dbus_message_is_method_call (message, GS_LISTENER_SERVICE, "Unlock"))
+	{
+		gs_listener_set_active (listener, FALSE);
 		return DBUS_HANDLER_RESULT_HANDLED;
 	}
 	if (dbus_message_is_method_call (message, GS_LISTENER_SERVICE, "Quit"))

--- a/src/mate-screensaver-command.c
+++ b/src/mate-screensaver-command.c
@@ -39,6 +39,7 @@
 
 static gboolean do_quit       = FALSE;
 static gboolean do_lock       = FALSE;
+static gboolean do_unlock     = FALSE;
 static gboolean do_cycle      = FALSE;
 static gboolean do_activate   = FALSE;
 static gboolean do_deactivate = FALSE;
@@ -69,6 +70,10 @@ static GOptionEntry entries [] =
 	{
 		"lock", 'l', 0, G_OPTION_ARG_NONE, &do_lock,
 		N_("Tells the running screensaver process to lock the screen immediately"), NULL
+	},
+	{
+		"unlock", 'u', 0, G_OPTION_ARG_NONE, &do_unlock,
+		N_("Tells the running screensaver process to unlock the screen immediately"), NULL
 	},
 	{
 		"cycle", 'c', 0, G_OPTION_ARG_NONE, &do_cycle,
@@ -421,6 +426,11 @@ do_command (DBusConnection *connection)
 	if (do_lock)
 	{
 		reply = screensaver_send_message_void (connection, "Lock", FALSE);
+	}
+
+	if (do_unlock)
+	{
+		reply = screensaver_send_message_void (connection, "Unlock", FALSE);
 	}
 
 	if (do_cycle)


### PR DESCRIPTION
…r via CLI.

As the use can unlock the session via cmdline anyway already (e.g. killall mate-screensaver, or via systemd), I'd like to propose providing the user with a generic way to unlock the screensaver via the ``mate-screensaver-command`` tool. This PR introduces the ``--unlock`` option.