### PR TITLE
Remove trailing whitespaces

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -193,7 +193,7 @@ dnl ---------------------------------------------------------------------------
 #
 AC_DEFUN([AC_CHECK_X_HEADER], [
   ac_save_CPPFLAGS="$CPPFLAGS"
-  if test \! -z "$includedir" ; then 
+  if test \! -z "$includedir" ; then
     CPPFLAGS="$CPPFLAGS -I$includedir"
   fi
   CPPFLAGS="$CPPFLAGS $X_CFLAGS"
@@ -204,7 +204,7 @@ AC_DEFUN([AC_CHECK_X_HEADER], [
 #
 AC_DEFUN([AC_TRY_X_COMPILE], [
   ac_save_CPPFLAGS="$CPPFLAGS"
-  if test \! -z "$includedir" ; then 
+  if test \! -z "$includedir" ; then
     CPPFLAGS="$CPPFLAGS -I$includedir"
   fi
   CPPFLAGS="$CPPFLAGS $X_CFLAGS"
@@ -220,7 +220,7 @@ AC_DEFUN([AC_CHECK_X_LIB], [
   ac_save_LDFLAGS="$LDFLAGS"
 #  ac_save_LIBS="$LIBS"
 
-  if test \! -z "$includedir" ; then 
+  if test \! -z "$includedir" ; then
     CPPFLAGS="$CPPFLAGS -I$includedir"
   fi
   # note: $X_CFLAGS includes $x_includes
@@ -335,7 +335,7 @@ if test "$with_mit" = yes; then
 
     if test "$have_mit" = no; then
       # Looks like some versions of XFree86 (whichever version
-      # it is that comes with RedHat Linux 2.0 -- I can't find a version 
+      # it is that comes with RedHat Linux 2.0 -- I can't find a version
       # number) put this in Xss instead of Xext.
       AC_CHECK_X_LIB(Xss, XScreenSaverRegister,
                      [have_mit=yes; SAVER_LIBS="$SAVER_LIBS -lXss"],

--- a/src/gs-lock-plug.c
+++ b/src/gs-lock-plug.c
@@ -240,7 +240,7 @@ do_user_switch (GSLockPlug *plug)
 												&error);
 
 		g_free (command);
-		
+
 		if (! res) {
 			gs_debug ("Unable to start GDM greeter: %s", error->message);
 			g_error_free (error);

--- a/src/mate-screensaver-preferences.c
+++ b/src/mate-screensaver-preferences.c
@@ -955,7 +955,7 @@ time_to_string_text (long time)
 	secs = g_strdup_printf (ngettext ("%d second",
 	                                  "%d seconds", sec), sec);
 
-	inc_len = strlen (g_strdup_printf (_("%s %s"), 
+	inc_len = strlen (g_strdup_printf (_("%s %s"),
 	                  g_strdup_printf (ngettext ("%d hour",
 	                                             "%d hours", 1), 1),
 	                  g_strdup_printf (ngettext ("%d minute",


### PR DESCRIPTION
`find . -regextype posix-extended -regex '.*\.(c|h|ac)' -exec sed --in-place 's/[[:space:]]\+$//' {} \+`

like rbuj do on [https://github.com/mate-desktop/mate-control-center/pull/463](https://github.com/mate-desktop/mate-control-center/pull/463).