### PR TITLE
drop libXxf86 dependency

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -414,23 +414,6 @@ elif test "$with_xf86gamma" != no; then
 fi
 
 dnl ---------------------------------------------------------------------------
-dnl - Check for XF86MiscSetGrabKeysState (but only bother if we are already
-dnl - using other XF86 stuff.)
-dnl ---------------------------------------------------------------------------
-
-
-have_xf86miscsetgrabkeysstate=no
-if test "$have_xf86gamma" = yes -o "$have_xf86vmode" = yes; then
-  AC_CHECK_X_LIB(Xxf86misc, XF86MiscSetGrabKeysState,
-                [have_xf86miscsetgrabkeysstate=yes],
-                [true], -lXext -lX11)
-  if test "$have_xf86miscsetgrabkeysstate" = yes ; then
-    SAVER_LIBS="$SAVER_LIBS -lXxf86misc"
-    AC_DEFINE(HAVE_XF86MISCSETGRABKEYSSTATE, , [Define this if you have the XF86MiscSetGrabKeysState function])
-  fi
-fi
-
-dnl ---------------------------------------------------------------------------
 dnl - The --enable-locking option
 dnl ---------------------------------------------------------------------------
 

--- a/src/gs-grab-x11.c
+++ b/src/gs-grab-x11.c
@@ -29,10 +29,6 @@
 #include <gdk/gdkx.h>
 #include <gtk/gtk.h>
 
-#ifdef HAVE_XF86MISCSETGRABKEYSSTATE
-# include <X11/extensions/xf86misc.h>
-#endif /* HAVE_XF86MISCSETGRABKEYSSTATE */
-
 #include "gs-window.h"
 #include "gs-grab.h"
 #include "gs-debug.h"
@@ -83,75 +79,11 @@ grab_string (int status)
 	}
 }
 
-#ifdef HAVE_XF86MISCSETGRABKEYSSTATE
-/* This function enables and disables the Ctrl-Alt-KP_star and
-   Ctrl-Alt-KP_slash hot-keys, which (in XFree86 4.2) break any
-   grabs and/or kill the grabbing client.  That would effectively
-   unlock the screen, so we don't like that.
-
-   The Ctrl-Alt-KP_star and Ctrl-Alt-KP_slash hot-keys only exist
-   if AllowDeactivateGrabs and/or AllowClosedownGrabs are turned on
-   in XF86Config.  I believe they are disabled by default.
-
-   This does not affect any other keys (specifically Ctrl-Alt-BS or
-   Ctrl-Alt-F1) but I wish it did.  Maybe it will someday.
- */
-static void
-xorg_lock_smasher_set_active (GSGrab  *grab,
-                              gboolean active)
-{
-	int status, event, error;
-	GdkDisplay *display;
-
-	display = gdk_display_get_default ();
-
-	if (!XF86MiscQueryExtension (GDK_DISPLAY_XDISPLAY (display), &event, &error))
-	{
-		gs_debug ("No XFree86-Misc extension present");
-		return;
-	}
-
-	if (active)
-	{
-		gs_debug ("Enabling the x.org grab smasher");
-	}
-	else
-	{
-		gs_debug ("Disabling the x.org grab smasher");
-	}
-
-	gdk_x11_display_error_trap_push (display);
-
-	status = XF86MiscSetGrabKeysState (GDK_DISPLAY_XDISPLAY (display), active);
-
-	gdk_display_sync (display);
-	error = gdk_x11_display_error_trap_pop (display);
-
-	if (active && status == MiscExtGrabStateAlready)
-	{
-		/* shut up, consider this success */
-		status = MiscExtGrabStateSuccess;
-	}
-
-        if (error == Success) {
-                gs_debug ("XF86MiscSetGrabKeysState(%s) returned %s\n",
-                          active ? "on" : "off",
-                          (status == MiscExtGrabStateSuccess ? "MiscExtGrabStateSuccess" :
-                           status == MiscExtGrabStateLocked  ? "MiscExtGrabStateLocked"  :
-                           status == MiscExtGrabStateAlready ? "MiscExtGrabStateAlready" :
-                           "unknown value"));
-        } else {
-                gs_debug ("XF86MiscSetGrabKeysState(%s) failed with error code %d\n",
-                          active ? "on" : "off", error);
-        }
-}
-#else
 static void
 xorg_lock_smasher_set_active (GSGrab  *grab,
                               gboolean active)
 {
 }
-#endif /* HAVE_XF86MISCSETGRABKEYSSTATE */
 
 static void
 prepare_window_grab_cb (GdkSeat   *seat,


### PR DESCRIPTION
The X server hasn't implemented it in over 10 years.
and it was dropped from debian since a long time.

fixes https://github.com/mate-desktop/mate-screensaver/issues/199