### PR TITLE
lock-dialog: add style_provider to current screen globally

### DIFF
--- a/src/gs-lock-plug.c
+++ b/src/gs-lock-plug.c
@@ -2003,7 +2003,6 @@ load_theme (GSLockPlug *plug)
 
 	filename = g_strdup_printf ("lock-dialog-%s.css", theme);
 	g_free (theme);
-
 	css = g_build_filename (GTKBUILDERDIR, filename, NULL);
 	g_free (filename);
 	if (g_file_test (css, G_FILE_TEST_IS_REGULAR))
@@ -2011,7 +2010,13 @@ load_theme (GSLockPlug *plug)
 		static GtkCssProvider *style_provider = NULL;
 
 		if (style_provider == NULL)
+		{
 			style_provider = gtk_css_provider_new ();
+
+			gtk_style_context_add_provider_for_screen (gdk_screen_get_default(),
+			                                           GTK_STYLE_PROVIDER (style_provider),
+			                                           GTK_STYLE_PROVIDER_PRIORITY_USER);
+		}
 
 		gtk_css_provider_load_from_path (style_provider, css, NULL);
 	}


### PR DESCRIPTION
```C
gtk_style_context_add_provider_for_screen (gdk_screen_get_default(),
                                           GTK_STYLE_PROVIDER (style_provider),
                                           GTK_STYLE_PROVIDER_PRIORITY_USER);

```
https://developer.gnome.org/gtk3/stable/GtkStyleContext.html#gtk-style-context-add-provider-for-screen

css data is located at /usr/share/mate-screensaver/lock-dialog-THEME.css, XDG_CONFIG_HOME/gtk-3.0/gtk.css, /usr/share/themes/...

/usr/share/mate-screensaver/lock-dialog-THEME.css file has highest priority, if exists:

```
  $ gsettings get org.mate.screensaver lock-dialog-theme
  'test'
  $ grep lock-dialog /usr/share/mate-screensaver/lock-dialog-test.css
  .lock-dialog.background {
  .lock-dialog frame {
  .lock-dialog notebook {
  .lock-dialog entry,
  .lock-dialog entry:focus {
  .lock-dialog button,
  .lock-dialog button:focus {
  .lock-dialog button:hover,
  .lock-dialog button:hover:active {
  ...
```
Otherwise: 
```
  $ ls /usr/share/mate-screensaver/
  lock-dialog-default.ui  lock-dialog-test.css  lock-dialog-test.ui  mate-screensaver-preferences.ui
  $ gsettings get org.mate.screensaver lock-dialog-theme
  'default'
  $ gsettings get org.mate.interface gtk-theme
  'TraditionalOk'
  $ grep lock-dialog /usr/share/themes/TraditionalOk/gtk-3.0/*.css
  /usr/share/themes/TraditionalOk/gtk-3.0/mate-applications.css:.lock-dialog {
  /usr/share/themes/TraditionalOk/gtk-3.0/mate-applications.css:.lock-dialog notebook {
```
Examples:

```
[robert@PC09 ~]$ sudo cp /usr/share/mate-screensaver/lock-dialog-default.ui /usr/share/mate-screensaver/lock-dialog-test.ui
[robert@PC09 ~]$ sudo wget -q -O /usr/share/mate-screensaver/lock-dialog-test.css https://gist.githubusercontent.com/geki-yaba/19262f9af9b2a6f838636e6f019e96a3/raw/24a5ee22a0338c6c145db15f363bcbe73c64630d/gistfile1.txt 
[robert@PC09 ~]$ gsettings set org.mate.screensaver lock-dialog-theme test
[robert@PC09 ~]$ gsettings set org.mate.interface gtk-theme TraditionalOk
```
![VirtualBox_Fedora 9_11_08_2019_16_25_37](https://user-images.githubusercontent.com/10171411/62835109-dfd40680-bc54-11e9-806d-d38c155ecaf2.png)

```
[robert@PC09 ~]$ gsettings get org.mate.screensaver lock-dialog-theme
'default'
[robert@PC09 ~]$ gsettings get org.mate.interface gtk-theme
'TraditionalOk'
```
![VirtualBox_Fedora 9_11_08_2019_14_23_55](https://user-images.githubusercontent.com/10171411/62833777-7e0ba080-bc44-11e9-8370-88025c9605a4.png)

```
[robert@PC09 ~]$ gsettings get org.mate.screensaver lock-dialog-theme
'default'
[robert@PC09 ~]$ gsettings get org.mate.interface gtk-theme
'Blue-Submarine'
```
![VirtualBox_Fedora 9_11_08_2019_14_23_04](https://user-images.githubusercontent.com/10171411/62833767-67fde000-bc44-11e9-923d-369c191c4105.png)

```
[robert@PC09 ~]$ gsettings get org.mate.screensaver lock-dialog-theme
'default'
[robert@PC09 ~]$ gsettings get org.mate.interface gtk-theme
'BlackMATE'
```
![VirtualBox_Fedora 9_11_08_2019_14_24_22](https://user-images.githubusercontent.com/10171411/62833780-8663db80-bc44-11e9-805e-a759c4416dfa.png)

Face image:
https://en.wikipedia.org/wiki/File:User_icon_2.svg
From [Tango Desktop Project](http://tango.freedesktop.org/Tango_Desktop_Project)