### PR TITLE
avoid redundant redeclarations

### DIFF
--- a/savers/gste-popsquares.c
+++ b/savers/gste-popsquares.c
@@ -32,8 +32,6 @@
 #include "gs-theme-engine.h"
 #include "gste-popsquares.h"
 
-static void     gste_popsquares_class_init (GSTEPopsquaresClass *klass);
-static void     gste_popsquares_init       (GSTEPopsquares      *engine);
 static void     gste_popsquares_finalize   (GObject             *object);
 static void     draw_frame                 (GSTEPopsquares      *pop,
                                             cairo_t *cr);

--- a/savers/gste-slideshow.c
+++ b/savers/gste-slideshow.c
@@ -32,8 +32,6 @@
 #include "gs-theme-engine.h"
 #include "gste-slideshow.h"
 
-static void     gste_slideshow_class_init (GSTESlideshowClass *klass);
-static void     gste_slideshow_init       (GSTESlideshow      *engine);
 static void     gste_slideshow_finalize   (GObject            *object);
 
 struct GSTESlideshowPrivate

--- a/src/copy-theme-dialog.c
+++ b/src/copy-theme-dialog.c
@@ -32,10 +32,6 @@
 #include "copy-theme-dialog.h"
 
 static void
-copy_theme_dialog_class_init (CopyThemeDialogClass *klass);
-static void
-copy_theme_dialog_init (CopyThemeDialog *dlg);
-static void
 add_file_to_dialog (gpointer data, gpointer user_data);
 static void
 single_copy_complete (GObject *source_object, GAsyncResult *res,

--- a/src/gs-fade.c
+++ b/src/gs-fade.c
@@ -56,8 +56,6 @@
 
 #endif /* HAVE_XF86VMODE_GAMMA */
 
-static void     gs_fade_class_init (GSFadeClass *klass);
-static void     gs_fade_init       (GSFade      *fade);
 static void     gs_fade_finalize   (GObject        *object);
 
 struct GSGammaInfo

--- a/src/gs-grab-x11.c
+++ b/src/gs-grab-x11.c
@@ -33,8 +33,6 @@
 #include "gs-grab.h"
 #include "gs-debug.h"
 
-static void     gs_grab_class_init (GSGrabClass *klass);
-static void     gs_grab_init       (GSGrab      *grab);
 static void     gs_grab_finalize   (GObject     *object);
 
 static gpointer grab_object = NULL;

--- a/src/gs-job.c
+++ b/src/gs-job.c
@@ -44,8 +44,6 @@
 
 #include "subprocs.h"
 
-static void gs_job_class_init (GSJobClass *klass);
-static void gs_job_init       (GSJob      *job);
 static void gs_job_finalize   (GObject    *object);
 
 typedef enum

--- a/src/gs-listener-dbus.c
+++ b/src/gs-listener-dbus.c
@@ -41,8 +41,6 @@
 #include "gs-marshal.h"
 #include "gs-debug.h"
 
-static void              gs_listener_class_init         (GSListenerClass *klass);
-static void              gs_listener_init               (GSListener      *listener);
 static void              gs_listener_finalize           (GObject         *object);
 
 static void              gs_listener_unregister_handler (DBusConnection  *connection,

--- a/src/gs-manager.c
+++ b/src/gs-manager.c
@@ -41,8 +41,6 @@
 #include "gs-fade.h"
 #include "gs-debug.h"
 
-static void gs_manager_class_init (GSManagerClass *klass);
-static void gs_manager_init       (GSManager      *manager);
 static void gs_manager_finalize   (GObject        *object);
 
 struct GSManagerPrivate

--- a/src/gs-monitor.c
+++ b/src/gs-monitor.c
@@ -43,8 +43,6 @@
 #include "gs-prefs.h"
 #include "gs-debug.h"
 
-static void gs_monitor_class_init(GSMonitorClass* klass);
-static void gs_monitor_init(GSMonitor* monitor);
 static void gs_monitor_finalize(GObject* object);
 
 struct GSMonitorPrivate {

--- a/src/gs-prefs.c
+++ b/src/gs-prefs.c
@@ -30,8 +30,6 @@
 
 #include "gs-prefs.h"
 
-static void gs_prefs_class_init (GSPrefsClass *klass);
-static void gs_prefs_init       (GSPrefs      *prefs);
 static void gs_prefs_finalize   (GObject      *object);
 
 #define LOCKDOWN_SETTINGS_SCHEMA "org.mate.lockdown"

--- a/src/gs-theme-manager.c
+++ b/src/gs-theme-manager.c
@@ -36,8 +36,6 @@
 #include "gs-theme-manager.h"
 #include "gs-debug.h"
 
-static void     gs_theme_manager_class_init (GSThemeManagerClass *klass);
-static void     gs_theme_manager_init       (GSThemeManager      *theme_manager);
 static void     gs_theme_manager_finalize   (GObject             *object);
 
 struct _GSThemeInfo

--- a/src/gs-watcher-x11.c
+++ b/src/gs-watcher-x11.c
@@ -37,8 +37,6 @@
 #include "gs-marshal.h"
 #include "gs-debug.h"
 
-static void     gs_watcher_class_init (GSWatcherClass *klass);
-static void     gs_watcher_init       (GSWatcher      *watcher);
 static void     gs_watcher_finalize   (GObject        *object);
 
 static gboolean watchdog_timer        (GSWatcher      *watcher);

--- a/src/gs-window-x11.c
+++ b/src/gs-window-x11.c
@@ -41,8 +41,6 @@
 #include <X11/extensions/shape.h>
 #endif
 
-static void gs_window_class_init (GSWindowClass *klass);
-static void gs_window_init       (GSWindow      *window);
 static void gs_window_finalize   (GObject       *object);
 
 static gboolean popup_dialog_idle (GSWindow *window);

--- a/src/mate-screensaver-preferences.c
+++ b/src/mate-screensaver-preferences.c
@@ -1337,7 +1337,9 @@ setup_for_root_user (void)
 }
 
 /* copied from gs-window-x11.c */
+#ifndef _GNU_SOURCE
 extern char **environ;
+#endif
 
 static gchar **
 spawn_make_environment_for_display (GdkDisplay *display,


### PR DESCRIPTION
Fixes the warnings:

```
gs-monitor.c:62:40: warning: redundant redeclaration of 'gs_monitor_init' [-Wredundant-decls]
gs-monitor.c:62:40: warning: redundant redeclaration of 'gs_monitor_class_init' [-Wredundant-decls]
gs-watcher-x11.c:79:40: warning: redundant redeclaration of 'gs_watcher_init' [-Wredundant-decls]
gs-watcher-x11.c:79:40: warning: redundant redeclaration of 'gs_watcher_class_init' [-Wredundant-decls]
gs-listener-dbus.c:151:41: warning: redundant redeclaration of 'gs_listener_init' [-Wredundant-decls]
gs-listener-dbus.c:151:41: warning: redundant redeclaration of 'gs_listener_class_init' [-Wredundant-decls]
gs-manager.c:121:40: warning: redundant redeclaration of 'gs_manager_init' [-Wredundant-decls]
gs-manager.c:121:40: warning: redundant redeclaration of 'gs_manager_class_init' [-Wredundant-decls]
gs-window-x11.c:143:39: warning: redundant redeclaration of 'gs_window_init' [-Wredundant-decls]
gs-window-x11.c:143:39: warning: redundant redeclaration of 'gs_window_class_init' [-Wredundant-decls]
gs-prefs.c:80:38: warning: redundant redeclaration of 'gs_prefs_init' [-Wredundant-decls]
gs-prefs.c:80:38: warning: redundant redeclaration of 'gs_prefs_class_init' [-Wredundant-decls]
gs-theme-manager.c:56:45: warning: redundant redeclaration of 'gs_theme_manager_init' [-Wredundant-decls]
gs-theme-manager.c:56:45: warning: redundant redeclaration of 'gs_theme_manager_class_init' [-Wredundant-decls]
gs-job.c:71:36: warning: redundant redeclaration of 'gs_job_init' [-Wredundant-decls]
gs-job.c:71:36: warning: redundant redeclaration of 'gs_job_class_init' [-Wredundant-decls]
gs-grab-x11.c:52:37: warning: redundant redeclaration of 'gs_grab_init' [-Wredundant-decls]
gs-grab-x11.c:52:37: warning: redundant redeclaration of 'gs_grab_class_init' [-Wredundant-decls]
gs-fade.c:122:37: warning: redundant redeclaration of 'gs_fade_init' [-Wredundant-decls]
gs-fade.c:122:37: warning: redundant redeclaration of 'gs_fade_class_init' [-Wredundant-decls]
mate-screensaver-preferences.c:1340:15: warning: redundant redeclaration of 'environ' [-Wredundant-decls]
copy-theme-dialog.c:86:46: warning: redundant redeclaration of 'copy_theme_dialog_init' [-Wredundant-decls]
copy-theme-dialog.c:86:46: warning: redundant redeclaration of 'copy_theme_dialog_class_init' [-Wredundant-decls]
gste-popsquares.c:60:45: warning: redundant redeclaration of 'gste_popsquares_init' [-Wredundant-decls]
gste-popsquares.c:60:45: warning: redundant redeclaration of 'gste_popsquares_class_init' [-Wredundant-decls]
gste-slideshow.c:92:44: warning: redundant redeclaration of 'gste_slideshow_init' [-Wredundant-decls]
gste-slideshow.c:92:44: warning: redundant redeclaration of 'gste_slideshow_class_init' [-Wredundant-decls]
```