### PR TITLE
Remove warning function declaration isn’t a prototype

### DIFF
--- a/src/mate-screensaver-preferences.c
+++ b/src/mate-screensaver-preferences.c
@@ -283,7 +283,7 @@ config_get_lock (gboolean *is_writable)
 }
 
 static gboolean
-config_get_lock_disabled ()
+config_get_lock_disabled (void)
 {
 	return g_settings_get_boolean (lockdown_settings, KEY_LOCK_DISABLE);
 }


### PR DESCRIPTION
```
mate-screensaver-preferences.c:286:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
  286 | config_get_lock_disabled ()
      | ^~~~~~~~~~~~~~~~~~~~~~~~
```