### PR TITLE
gs-window-x11: Remove warning "variable ‘widget’ set but not used"

### DIFF
--- a/src/gs-window-x11.c
+++ b/src/gs-window-x11.c
@@ -380,7 +380,7 @@ gs_window_move_resize_window (GSWindow *window,
 	GdkWindow *gdkwindow;
 
 	widget = GTK_WIDGET (window);
-	gdkwindow = gtk_widget_get_window (GTK_WIDGET (window));
+	gdkwindow = gtk_widget_get_window (widget);
 
 	g_assert (gtk_widget_get_realized (widget));
 


### PR DESCRIPTION
```
gs-window-x11.c: In function ‘gs_window_move_resize_window’:
gs-window-x11.c:379:13: warning: variable ‘widget’ set but not used [-Wunused-but-set-variable]
  379 |  GtkWidget *widget;
      |             ^~~~~~
```