### PR TITLE
Remove warning -Wshadow

### DIFF
--- a/savers/floaters.c
+++ b/savers/floaters.c
@@ -74,49 +74,6 @@
 #define GAMMA 2.2
 #endif
 
-static gboolean should_show_paths = FALSE;
-static gboolean should_do_rotations = FALSE;
-static gboolean should_print_stats = FALSE;
-static gint max_floater_count = FLOATER_DEFAULT_COUNT;
-static gchar *geometry = NULL;
-static gchar **filenames = NULL;
-
-static GOptionEntry options[] =
-{
-	{
-		"show-paths", 'p', 0, G_OPTION_ARG_NONE, &should_show_paths,
-		N_("Show paths that images follow"), NULL
-	},
-
-	{
-		"do-rotations", 'r', 0, G_OPTION_ARG_NONE, &should_do_rotations,
-		N_("Occasionally rotate images as they move"), NULL
-	},
-
-	{
-		"print-stats", 's', 0, G_OPTION_ARG_NONE, &should_print_stats,
-		N_("Print out frame rate and other statistics"), NULL
-	},
-
-	{
-		"number-of-images", 'n', 0, G_OPTION_ARG_INT, &max_floater_count,
-		N_("The maximum number of images to keep on screen"), N_("MAX_IMAGES")
-	},
-
-	{
-		"geometry", 0, 0, G_OPTION_ARG_STRING, &geometry,
-		N_("The initial size and position of window"), N_("WIDTHxHEIGHT+X+Y")
-	},
-
-	{
-		G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_FILENAME_ARRAY, &filenames,
-		N_("The source image to use"), NULL
-	},
-
-	{NULL}
-};
-
-
 typedef struct _Point Point;
 typedef struct _Path Path;
 typedef struct _Rectangle Rectangle;
@@ -1170,9 +1127,29 @@ main (int   argc,
 	ScreenSaver     *screen_saver;
 	GtkWidget       *window;
 	GtkWidget       *drawing_area;
-	GError *error;
+	gboolean         should_show_paths = FALSE;
+	gboolean         should_do_rotations = FALSE;
+	gboolean         should_print_stats = FALSE;
+	gint             max_floater_count = FLOATER_DEFAULT_COUNT;
+	gchar           *geometry = NULL;
+	gchar          **filenames = NULL;
+	GError          *error = NULL;
 
-	error = NULL;
+	GOptionEntry options[] = {
+	        { "show-paths", 'p', 0, G_OPTION_ARG_NONE, &should_show_paths,
+		  N_("Show paths that images follow"), NULL },
+		{ "do-rotations", 'r', 0, G_OPTION_ARG_NONE, &should_do_rotations,
+		  N_("Occasionally rotate images as they move"), NULL },
+		{ "print-stats", 's', 0, G_OPTION_ARG_NONE, &should_print_stats,
+		  N_("Print out frame rate and other statistics"), NULL },
+		{ "number-of-images", 'n', 0, G_OPTION_ARG_INT, &max_floater_count,
+		  N_("The maximum number of images to keep on screen"), N_("MAX_IMAGES") },
+		{ "geometry", 0, 0, G_OPTION_ARG_STRING, &geometry,
+		  N_("The initial size and position of window"), N_("WIDTHxHEIGHT+X+Y") },
+		{ G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_FILENAME_ARRAY, &filenames,
+		  N_("The source image to use"), NULL },
+		{NULL}
+	};
 
 	bindtextdomain (GETTEXT_PACKAGE, MATELOCALEDIR);
 	bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");

--- a/src/mate-screensaver-dialog.c
+++ b/src/mate-screensaver-dialog.c
@@ -429,7 +429,8 @@ static gboolean popup_dialog_idle(gpointer data)
    If the executable is setuid root, then these initializations
    are run as root, before discarding privileges.
 */
-static gboolean privileged_initialization(int* argc, char** argv, gboolean verbose)
+static gboolean
+privileged_initialization (int* argc, char** argv)
 {
 	gboolean ret;
 	char* nolock_reason;
@@ -471,7 +472,8 @@ static gboolean privileged_initialization(int* argc, char** argv, gboolean verbo
  *
  * Figure out what locking mechanisms are supported.
  */
-static gboolean lock_initialization (int* argc, char** argv, char** nolock_reason, gboolean verbose)
+static gboolean
+lock_initialization (int* argc, char** argv, char** nolock_reason)
 {
 	if (nolock_reason != NULL)
 	{
@@ -560,7 +562,7 @@ int main(int argc, char** argv)
 
 	gs_profile_start(NULL);
 
-	if (!privileged_initialization(&argc, argv, verbose))
+	if (!privileged_initialization (&argc, argv))
 	{
 		response_lock_init_failed();
 		exit(1);
@@ -585,7 +587,7 @@ int main(int argc, char** argv)
 		exit(1);
 	}
 
-	if (!lock_initialization(&argc, argv, &nolock_reason, verbose))
+	if (!lock_initialization(&argc, argv, &nolock_reason))
 	{
 		if (nolock_reason != NULL)
 		{

--- a/src/mate-screensaver-preferences.c
+++ b/src/mate-screensaver-preferences.c
@@ -192,7 +192,7 @@ config_get_theme (gboolean *is_writable)
 }
 
 static gchar **
-get_all_theme_ids (GSThemeManager *theme_manager)
+get_all_theme_ids (void)
 {
 	gchar **ids = NULL;
 	GSList *entries;
@@ -228,7 +228,7 @@ config_set_theme (const char *theme_id)
 		mode = GS_MODE_RANDOM;
 
 		/* set the themes key to contain all available screensavers */
-		strv = get_all_theme_ids (theme_manager);
+		strv = get_all_theme_ids ();
 	}
 	else
 	{
@@ -297,8 +297,7 @@ config_set_lock (gboolean lock)
 }
 
 static void
-job_set_theme (GSJob      *job,
-               const char *theme)
+job_set_theme (const char *theme)
 {
 	GSThemeInfo *info;
 	const char  *command;
@@ -362,13 +361,13 @@ preview_set_theme (GtkWidget  *widget,
 	{
 		gchar **themes;
 
-		themes = get_all_theme_ids (theme_manager);
+		themes = get_all_theme_ids ();
 		if (themes != NULL)
 		{
 			gint32  i;
 
 			i = g_random_int_range (0, g_strv_length (themes));
-                        job_set_theme (job, themes[i]);
+                        job_set_theme (themes[i]);
                         g_strfreev (themes);
 
 			gs_job_start (job);
@@ -376,7 +375,7 @@ preview_set_theme (GtkWidget  *widget,
 	}
 	else
 	{
-		job_set_theme (job, theme);
+		job_set_theme (theme);
 		gs_job_start (job);
 	}
 }
@@ -1757,7 +1756,7 @@ init_capplet (void)
 	mode = g_settings_get_enum (screensaver_settings, KEY_MODE);
 	if (mode == GS_MODE_RANDOM) {
 		gchar **list;
-		list = get_all_theme_ids (theme_manager);
+		list = get_all_theme_ids ();
 		g_settings_set_strv (screensaver_settings, KEY_THEMES, (const gchar * const*) list);
 		g_strfreev (list);
 	}


### PR DESCRIPTION
```
mate-screensaver-preferences.c:195:36: warning: declaration of 'theme_manager' shadows a global declaration [-Wshadow]
  195 | get_all_theme_ids (GSThemeManager *theme_manager)
      |                    ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
--
mate-screensaver-preferences.c:300:28: warning: declaration of 'job' shadows a global declaration [-Wshadow]
  300 | job_set_theme (GSJob      *job,
      |                ~~~~~~~~~~~~^~~
--
mate-screensaver-dialog.c:432:76: warning: declaration of 'verbose' shadows a global declaration [-Wshadow]
  432 | static gboolean privileged_initialization(int* argc, char** argv, gboolean verbose)
      |                                                                   ~~~~~~~~~^~~~~~~
--
mate-screensaver-dialog.c:474:93: warning: declaration of 'verbose' shadows a global declaration [-Wshadow]
  474 | static gboolean lock_initialization (int* argc, char** argv, char** nolock_reason, gboolean verbose)
      |                                                                                    ~~~~~~~~~^~~~~~~
--
floaters.c:839:36: warning: declaration of 'max_floater_count' shadows a global declaration [-Wshadow]
  839 |                   gint             max_floater_count,
      |                   ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
--
floaters.c:840:36: warning: declaration of 'should_do_rotations' shadows a global declaration [-Wshadow]
  840 |                   gboolean         should_do_rotations,
      |                   ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
--
floaters.c:841:36: warning: declaration of 'should_show_paths' shadows a global declaration [-Wshadow]
  841 |                   gboolean         should_show_paths)
      |                   ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
```