### PR TITLE
Corrected several icon translations (which broke the .desktop icons)

### DIFF
--- a/po/ca.po
+++ b/po/ca.po
@@ -36,7 +36,7 @@ msgstr "Establiu les preferències de l'estalvi de pantalla"
 #: data/mate-screensaver-preferences.desktop.in:6
 #: src/mate-screensaver.desktop.in.in:7
 msgid "preferences-desktop-screensaver"
-msgstr "preferences-desktop-screensaver"
+msgstr ""
 
 #. Translators: Search terms to find this application. Do NOT translate or
 #. localize the semicolons! The list MUST also end with a semicolon!
@@ -97,7 +97,7 @@ msgstr "Temes de l'estalvi de pantalla"
 #. file name)!
 #: data/mate-screensaver.directory.desktop.in:7
 msgid "screensaver"
-msgstr "screensaver"
+msgstr ""
 
 #. Translators: This is the name of a desktop background image that shows
 #. outer space images.

--- a/po/cs.po
+++ b/po/cs.po
@@ -42,7 +42,7 @@ msgstr "Nastaví šetřič obrazovky"
 #: data/mate-screensaver-preferences.desktop.in:6
 #: src/mate-screensaver.desktop.in.in:7
 msgid "preferences-desktop-screensaver"
-msgstr "preferences-desktop-screensaver"
+msgstr ""
 
 #. Translators: Search terms to find this application. Do NOT translate or
 #. localize the semicolons! The list MUST also end with a semicolon!
@@ -103,7 +103,7 @@ msgstr "Motivy šetřiče obrazovky"
 #. file name)!
 #: data/mate-screensaver.directory.desktop.in:7
 msgid "screensaver"
-msgstr "screensaver"
+msgstr ""
 
 #. Translators: This is the name of a desktop background image that shows
 #. outer space images.

--- a/po/da.po
+++ b/po/da.po
@@ -36,7 +36,7 @@ msgstr "Sæt dine indstillinger for pauseskærm"
 #: data/mate-screensaver-preferences.desktop.in:6
 #: src/mate-screensaver.desktop.in.in:7
 msgid "preferences-desktop-screensaver"
-msgstr "preferences-desktop-screensaver"
+msgstr ""
 
 #. Translators: Search terms to find this application. Do NOT translate or
 #. localize the semicolons! The list MUST also end with a semicolon!
@@ -97,7 +97,7 @@ msgstr "Pauseskærm temaer"
 #. file name)!
 #: data/mate-screensaver.directory.desktop.in:7
 msgid "screensaver"
-msgstr "pauseskærm"
+msgstr ""
 
 #. Translators: This is the name of a desktop background image that shows
 #. outer space images.

--- a/po/es.po
+++ b/po/es.po
@@ -41,7 +41,7 @@ msgstr "Configure el salvapantallas"
 #: data/mate-screensaver-preferences.desktop.in:6
 #: src/mate-screensaver.desktop.in.in:7
 msgid "preferences-desktop-screensaver"
-msgstr "preferences-desktop-screensaver"
+msgstr ""
 
 #. Translators: Search terms to find this application. Do NOT translate or
 #. localize the semicolons! The list MUST also end with a semicolon!
@@ -102,7 +102,7 @@ msgstr "Temas del salvapantallas"
 #. file name)!
 #: data/mate-screensaver.directory.desktop.in:7
 msgid "screensaver"
-msgstr "screensaver"
+msgstr ""
 
 #. Translators: This is the name of a desktop background image that shows
 #. outer space images.

--- a/po/fr.po
+++ b/po/fr.po
@@ -42,7 +42,7 @@ msgstr "Définir vos préférences pour l'économiseur d'écran"
 #: data/mate-screensaver-preferences.desktop.in:6
 #: src/mate-screensaver.desktop.in.in:7
 msgid "preferences-desktop-screensaver"
-msgstr "preferences-desktop-screensaver"
+msgstr ""
 
 #. Translators: Search terms to find this application. Do NOT translate or
 #. localize the semicolons! The list MUST also end with a semicolon!
@@ -104,7 +104,7 @@ msgstr "Thèmes de l'économiseur d'écran"
 #. file name)!
 #: data/mate-screensaver.directory.desktop.in:7
 msgid "screensaver"
-msgstr "Économiseur d'écran"
+msgstr ""
 
 #. Translators: This is the name of a desktop background image that shows
 #. outer space images.

--- a/po/gl.po
+++ b/po/gl.po
@@ -35,7 +35,7 @@ msgstr "Defina as súas preferencias para o protector de pantalla"
 #: data/mate-screensaver-preferences.desktop.in:6
 #: src/mate-screensaver.desktop.in.in:7
 msgid "preferences-desktop-screensaver"
-msgstr "preferences-desktop-screensaver"
+msgstr ""
 
 #. Translators: Search terms to find this application. Do NOT translate or
 #. localize the semicolons! The list MUST also end with a semicolon!
@@ -96,7 +96,7 @@ msgstr "Temas do protector de pantalla"
 #. file name)!
 #: data/mate-screensaver.directory.desktop.in:7
 msgid "screensaver"
-msgstr "screensaver"
+msgstr ""
 
 #. Translators: This is the name of a desktop background image that shows
 #. outer space images.

--- a/po/he.po
+++ b/po/he.po
@@ -38,7 +38,7 @@ msgstr "קבע את העדפות שומר המסך"
 #: data/mate-screensaver-preferences.desktop.in:6
 #: src/mate-screensaver.desktop.in.in:7
 msgid "preferences-desktop-screensaver"
-msgstr "preferences-desktop-screensaver"
+msgstr ""
 
 #. Translators: Search terms to find this application. Do NOT translate or
 #. localize the semicolons! The list MUST also end with a semicolon!

--- a/po/hu.po
+++ b/po/hu.po
@@ -39,7 +39,7 @@ msgstr "A képernyővédő tulajdonságainak beállítása"
 #: data/mate-screensaver-preferences.desktop.in:6
 #: src/mate-screensaver.desktop.in.in:7
 msgid "preferences-desktop-screensaver"
-msgstr "tulajdonságok-asztal-képernyővédő"
+msgstr ""
 
 #. Translators: Search terms to find this application. Do NOT translate or
 #. localize the semicolons! The list MUST also end with a semicolon!

--- a/po/id.po
+++ b/po/id.po
@@ -39,7 +39,7 @@ msgstr "Tentukan setingan screensaver Anda"
 #: data/mate-screensaver-preferences.desktop.in:6
 #: src/mate-screensaver.desktop.in.in:7
 msgid "preferences-desktop-screensaver"
-msgstr "preferences-desktop-screensaver"
+msgstr ""
 
 #. Translators: Search terms to find this application. Do NOT translate or
 #. localize the semicolons! The list MUST also end with a semicolon!
@@ -100,7 +100,7 @@ msgstr "Tema screensaver"
 #. file name)!
 #: data/mate-screensaver.directory.desktop.in:7
 msgid "screensaver"
-msgstr "screensaver"
+msgstr ""
 
 #. Translators: This is the name of a desktop background image that shows
 #. outer space images.

--- a/po/it.po
+++ b/po/it.po
@@ -39,7 +39,7 @@ msgstr "Imposta le preferenze del salvaschermo"
 #: data/mate-screensaver-preferences.desktop.in:6
 #: src/mate-screensaver.desktop.in.in:7
 msgid "preferences-desktop-screensaver"
-msgstr "preferences-desktop-screensaver"
+msgstr ""
 
 #. Translators: Search terms to find this application. Do NOT translate or
 #. localize the semicolons! The list MUST also end with a semicolon!
@@ -100,7 +100,7 @@ msgstr "Temi del salvaschermo"
 #. file name)!
 #: data/mate-screensaver.directory.desktop.in:7
 msgid "screensaver"
-msgstr "screensaver"
+msgstr ""
 
 #. Translators: This is the name of a desktop background image that shows
 #. outer space images.

--- a/po/lt.po
+++ b/po/lt.po
@@ -37,7 +37,7 @@ msgstr "Nurodykite ekrano užsklandos nustatymus"
 #: data/mate-screensaver-preferences.desktop.in:6
 #: src/mate-screensaver.desktop.in.in:7
 msgid "preferences-desktop-screensaver"
-msgstr "preferences-desktop-screensaver"
+msgstr ""
 
 #. Translators: Search terms to find this application. Do NOT translate or
 #. localize the semicolons! The list MUST also end with a semicolon!
@@ -98,7 +98,7 @@ msgstr "Ekrano užsklandos temos"
 #. file name)!
 #: data/mate-screensaver.directory.desktop.in:7
 msgid "screensaver"
-msgstr "screensaver"
+msgstr ""
 
 #. Translators: This is the name of a desktop background image that shows
 #. outer space images.

--- a/po/ms.po
+++ b/po/ms.po
@@ -35,7 +35,7 @@ msgstr "Tetapkan keutamaan penyelamat skrin anda"
 #: data/mate-screensaver-preferences.desktop.in:6
 #: src/mate-screensaver.desktop.in.in:7
 msgid "preferences-desktop-screensaver"
-msgstr "preferences-desktop-screensaver"
+msgstr ""
 
 #. Translators: Search terms to find this application. Do NOT translate or
 #. localize the semicolons! The list MUST also end with a semicolon!
@@ -96,7 +96,7 @@ msgstr "Tema penyelamat skrin"
 #. file name)!
 #: data/mate-screensaver.directory.desktop.in:7
 msgid "screensaver"
-msgstr "screensaver"
+msgstr ""
 
 #. Translators: This is the name of a desktop background image that shows
 #. outer space images.

--- a/po/nl.po
+++ b/po/nl.po
@@ -38,7 +38,7 @@ msgstr "Voorkeuren voor de schermbeveiliging instellen"
 #: data/mate-screensaver-preferences.desktop.in:6
 #: src/mate-screensaver.desktop.in.in:7
 msgid "preferences-desktop-screensaver"
-msgstr "preferences-desktop-screensaver"
+msgstr ""
 
 #. Translators: Search terms to find this application. Do NOT translate or
 #. localize the semicolons! The list MUST also end with a semicolon!
@@ -101,7 +101,7 @@ msgstr "Schermbeveiligingsthema's"
 #. file name)!
 #: data/mate-screensaver.directory.desktop.in:7
 msgid "screensaver"
-msgstr "schermbeveiliging"
+msgstr ""
 
 #. Translators: This is the name of a desktop background image that shows
 #. outer space images.

--- a/po/oc.po
+++ b/po/oc.po
@@ -37,7 +37,7 @@ msgstr "Definir vòstras preferéncias per l'estalviador d'ecran"
 #: data/mate-screensaver-preferences.desktop.in:6
 #: src/mate-screensaver.desktop.in.in:7
 msgid "preferences-desktop-screensaver"
-msgstr "preferences-desktop-screensaver"
+msgstr ""
 
 #. Translators: Search terms to find this application. Do NOT translate or
 #. localize the semicolons! The list MUST also end with a semicolon!
@@ -98,7 +98,7 @@ msgstr "Tèmas d'estalviador d'ecran"
 #. file name)!
 #: data/mate-screensaver.directory.desktop.in:7
 msgid "screensaver"
-msgstr "screensaver"
+msgstr ""
 
 #. Translators: This is the name of a desktop background image that shows
 #. outer space images.

--- a/po/pt.po
+++ b/po/pt.po
@@ -40,7 +40,7 @@ msgstr "Defina as suas preferências de proteção de ecrã"
 #: data/mate-screensaver-preferences.desktop.in:6
 #: src/mate-screensaver.desktop.in.in:7
 msgid "preferences-desktop-screensaver"
-msgstr "preferences-desktop-screensaver"
+msgstr ""
 
 #. Translators: Search terms to find this application. Do NOT translate or
 #. localize the semicolons! The list MUST also end with a semicolon!
@@ -101,7 +101,7 @@ msgstr "Temas do Protetor de Ecrã"
 #. file name)!
 #: data/mate-screensaver.directory.desktop.in:7
 msgid "screensaver"
-msgstr "screensaver"
+msgstr ""
 
 #. Translators: This is the name of a desktop background image that shows
 #. outer space images.

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -104,7 +104,7 @@ msgstr "Temas de proteção de tela"
 #. file name)!
 #: data/mate-screensaver.directory.desktop.in:7
 msgid "screensaver"
-msgstr "protetor de tela"
+msgstr ""
 
 #. Translators: This is the name of a desktop background image that shows
 #. outer space images.

--- a/po/ru.po
+++ b/po/ru.po
@@ -39,7 +39,7 @@ msgstr "Параметры хранителя экрана"
 #: data/mate-screensaver-preferences.desktop.in:6
 #: src/mate-screensaver.desktop.in.in:7
 msgid "preferences-desktop-screensaver"
-msgstr "preferences-desktop-screensaver"
+msgstr ""
 
 #. Translators: Search terms to find this application. Do NOT translate or
 #. localize the semicolons! The list MUST also end with a semicolon!
@@ -100,7 +100,7 @@ msgstr "Темы хранителя экрана"
 #. file name)!
 #: data/mate-screensaver.directory.desktop.in:7
 msgid "screensaver"
-msgstr "screensaver"
+msgstr ""
 
 #. Translators: This is the name of a desktop background image that shows
 #. outer space images.

--- a/po/sr.po
+++ b/po/sr.po
@@ -35,7 +35,7 @@ msgstr "Подесите поставке чувара екрана"
 #: data/mate-screensaver-preferences.desktop.in:6
 #: src/mate-screensaver.desktop.in.in:7
 msgid "preferences-desktop-screensaver"
-msgstr "preferences-desktop-screensaver"
+msgstr ""
 
 #. Translators: Search terms to find this application. Do NOT translate or
 #. localize the semicolons! The list MUST also end with a semicolon!
@@ -96,7 +96,7 @@ msgstr "Теме чувара екрана"
 #. file name)!
 #: data/mate-screensaver.directory.desktop.in:7
 msgid "screensaver"
-msgstr "screensaver"
+msgstr ""
 
 #. Translators: This is the name of a desktop background image that shows
 #. outer space images.

--- a/po/sv.po
+++ b/po/sv.po
@@ -42,7 +42,7 @@ msgstr "Ställ in dina skärmsläckarinställningar"
 #: data/mate-screensaver-preferences.desktop.in:6
 #: src/mate-screensaver.desktop.in.in:7
 msgid "preferences-desktop-screensaver"
-msgstr "preferences-desktop-screensaver"
+msgstr ""
 
 #. Translators: Search terms to find this application. Do NOT translate or
 #. localize the semicolons! The list MUST also end with a semicolon!
@@ -103,7 +103,7 @@ msgstr "Skärmsläckarteman"
 #. file name)!
 #: data/mate-screensaver.directory.desktop.in:7
 msgid "screensaver"
-msgstr "screensaver"
+msgstr ""
 
 #. Translators: This is the name of a desktop background image that shows
 #. outer space images.

--- a/po/uk.po
+++ b/po/uk.po
@@ -38,7 +38,7 @@ msgstr "Встановити параметри зберігача екрану"
 #: data/mate-screensaver-preferences.desktop.in:6
 #: src/mate-screensaver.desktop.in.in:7
 msgid "preferences-desktop-screensaver"
-msgstr "preferences-desktop-screensaver"
+msgstr ""
 
 #. Translators: Search terms to find this application. Do NOT translate or
 #. localize the semicolons! The list MUST also end with a semicolon!
@@ -101,7 +101,7 @@ msgstr "Теми зберігача екрану"
 #. file name)!
 #: data/mate-screensaver.directory.desktop.in:7
 msgid "screensaver"
-msgstr "зберігач екрану"
+msgstr ""
 
 #. Translators: This is the name of a desktop background image that shows
 #. outer space images.

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -36,7 +36,7 @@ msgstr "設定螢幕保護程式"
 #: data/mate-screensaver-preferences.desktop.in:6
 #: src/mate-screensaver.desktop.in.in:7
 msgid "preferences-desktop-screensaver"
-msgstr "preferences-desktop-screensaver"
+msgstr ""
 
 #. Translators: Search terms to find this application. Do NOT translate or
 #. localize the semicolons! The list MUST also end with a semicolon!
@@ -97,7 +97,7 @@ msgstr "螢幕保護程式布景主題"
 #. file name)!
 #: data/mate-screensaver.directory.desktop.in:7
 msgid "screensaver"
-msgstr "screensaver"
+msgstr ""
 
 #. Translators: This is the name of a desktop background image that shows
 #. outer space images.


### PR DESCRIPTION
This string should not be translated at all (and it's not available on Transifex for translation, I checked). Similar fix as https://github.com/mate-desktop/mate-screensaver/pull/240 