### PR TITLE
Allow change of time and date formats on lock screen.

### DIFF
--- a/data/org.mate.screensaver.gschema.xml.in
+++ b/data/org.mate.screensaver.gschema.xml.in
@@ -75,6 +75,16 @@
       <summary>Theme for lock dialog</summary>
       <description>Theme to use for the lock dialog</description>
     </key>
+    <key name="lock-dialog-time-format" type="s">
+      <default>'locale'</default>
+      <summary>Format for time on lock dialog</summary>
+      <description>Format do display the time on lock dialog. Default is 'locale' which uses default format for current locale. Custom values should be set according to g-date-time-format. Try %R for 24H format.</description>
+    </key>
+    <key name="lock-dialog-date-format" type="s">
+      <default>'locale'</default>
+      <summary>Format for date on lock dialog</summary>
+      <description>Format do display the date on lock dialog. Default is 'locale' which uses default format for current locale. Custom values should be set according to g-date-time-format. Try %F for ISO 8601 date format. </description>
+    </key>
     <key name="status-message-enabled" type="b">
       <default>true</default>
       <summary>Allow the session status message to be displayed</summary>

--- a/src/gs-lock-plug.c
+++ b/src/gs-lock-plug.c
@@ -58,6 +58,10 @@
 
 #define KEY_LOCK_DIALOG_THEME "lock-dialog-theme"
 
+#define KEY_LOCK_DIALOG_T_FMT "lock-dialog-time-format"
+#define KEY_LOCK_DIALOG_D_FMT "lock-dialog-date-format"
+
+
 #define MDM_FLEXISERVER_COMMAND "mdmflexiserver"
 #define MDM_FLEXISERVER_ARGS    "--startnew Standard"
 
@@ -293,12 +297,42 @@ date_time_update (GSLockPlug *plug)
 	GDateTime *datetime;
 	gchar *time;
 	gchar *date;
+	gchar *tfmt;
+	gchar *dfmt;
+
 	gchar *str;
 
+	GSettings *settings;
+
+	settings = g_settings_new (GSETTINGS_SCHEMA);
+	tfmt = g_settings_get_string (settings, KEY_LOCK_DIALOG_T_FMT);
+	dfmt = g_settings_get_string (settings, KEY_LOCK_DIALOG_D_FMT);
+	g_object_unref (settings);
+
+	/* Time/Date formating https://developer.gnome.org/glib/stable/glib-GDateTime.html#g-date-time-format */
+
 	datetime = g_date_time_new_now_local ();
-	time = g_date_time_format (datetime, "%X");
-	/* Translators: Date format, see https://developer.gnome.org/glib/stable/glib-GDateTime.html#g-date-time-format */
-	date = g_date_time_format (datetime, _("%A, %B %e"));
+	if (g_strcmp0(tfmt, "locale") == 0)
+	{
+		// Use locale default format
+		time = g_date_time_format (datetime, "%X");
+	}
+	else
+	{
+		// Apply user defined format
+		time = g_date_time_format (datetime, tfmt);
+	}
+
+	if (g_strcmp0(dfmt, "locale") == 0)
+	{
+		// Use locale default format
+		date = g_date_time_format (datetime, _("%A, %B %e"));
+	}
+	else
+	{
+		// Apply user defined format
+		date = g_date_time_format (datetime, dfmt);
+	}
 
 	str = g_strdup_printf ("<span size=\"xx-large\" weight=\"ultrabold\">%s</span>", time);
 	gtk_label_set_text (GTK_LABEL (plug->priv->auth_time_label), str);
@@ -312,6 +346,8 @@ date_time_update (GSLockPlug *plug)
 
 	g_free (time);
 	g_free (date);
+	g_free (tfmt);
+	g_free (dfmt);
 	g_date_time_unref (datetime);
 }
 


### PR DESCRIPTION
This change allows modification of default time and date format defined by current locale.
Closes https://github.com/mate-desktop/mate-screensaver/issues/100

Default ('local') settings maintains old behavior.
User is able to use any format defined by https://developer.gnome.org/glib/stable/glib-GDateTime.html#g-date-time-format.

Examples:
%R for time means 24H format.
%F for date means YYYY-MM-DD (ISO 8601 format).
