### PR TITLE
build: show configure summary using a pretty format

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1133,50 +1133,52 @@ helper/Makefile
 ])
 
 echo "
-                    mate-screensaver $VERSION
-                    ========================
+Configure summary:
 
-        prefix:                   ${prefix}
-        exec_prefix:              ${exec_prefix}
-        libdir:                   ${EXPANDED_LIBDIR}
-        bindir:                   ${EXPANDED_BINDIR}
-        sysconfdir:               ${EXPANDED_SYSCONFDIR}
-        localstatedir:            ${EXPANDED_LOCALSTATEDIR}
-        datadir:                  ${EXPANDED_DATADIR}
-        PAM prefix:               ${PAM_PREFIX}
-        source code location:     ${srcdir}
-        compiler:                 ${CC}
-        cflags:                   ${CFLAGS}
-        Warning flags:            ${WARN_CFLAGS}
-        Base libs:                ${MATE_SCREENSAVER_LIBS}
-        Extension libs:           ${SAVER_LIBS}
-        Maintainer mode:          ${USE_MAINTAINER_MODE}
-        Docs enabled:             ${enable_docbook_docs}
+    ${PACKAGE_STRING}
+    `echo $PACKAGE_STRING | sed "s/./=/g"`
 
-        GL:                       ${have_libgl}
+    prefix .......................: ${prefix}
+    exec_prefix ..................: ${exec_prefix}
+    libdir .......................: ${EXPANDED_LIBDIR}
+    bindir .......................: ${EXPANDED_BINDIR}
+    sysconfdir ...................: ${EXPANDED_SYSCONFDIR}
+    localstatedir ................: ${EXPANDED_LOCALSTATEDIR}
+    datadir ......................: ${EXPANDED_DATADIR}
+    PAM prefix ...................: ${PAM_PREFIX}
+    source code location .........: ${srcdir}
+    compiler .....................: ${CC}
+    cflags .......................: ${CFLAGS}
+    Warning flags ................: ${WARN_CFLAGS}
+    Base libs ....................: ${MATE_SCREENSAVER_LIBS}
+    Extension libs ...............: ${SAVER_LIBS}
+    Maintainer mode ..............: ${USE_MAINTAINER_MODE}
+    Docs enabled .................: ${enable_docbook_docs}
 
-        Screen locking enabled:   ${enable_locking}
-        Show keyboard indicator:  ${with_kbd_layout_indicator}
-        systemd support:          ${use_systemd}
-        elogind support:          ${use_elogind}
-        ConsoleKit support:       ${use_console_kit}
-        libnotify support:        ${have_libnotify}
-        PAM support:              ${have_pam}
-        bsd_auth(3) support:      ${have_bsdauth}
-        Have shadow passwords:    ${have_shadow}
-        Have adjunct shadow:      ${have_shadow_adjunct}
-        Have enhanced shadow:     ${have_shadow_enhanced}
-        Have HPUX shadow:         ${have_shadow_hpux}
-        Have password helper:     ${have_passwd_helper}
-        Authentication scheme:    ${AUTH_SCHEME}"
+    GL ...........................: ${have_libgl}
+
+    Screen locking enabled .......: ${enable_locking}
+    Show keyboard indicator ......: ${with_kbd_layout_indicator}
+    systemd support ..............: ${use_systemd}
+    elogind support ..............: ${use_elogind}
+    ConsoleKit support ...........: ${use_console_kit}
+    libnotify support ............: ${have_libnotify}
+    PAM support ..................: ${have_pam}
+    bsd_auth(3) support ..........: ${have_bsdauth}
+    Have shadow passwords ........: ${have_shadow}
+    Have adjunct shadow ..........: ${have_shadow_adjunct}
+    Have enhanced shadow .........: ${have_shadow_enhanced}
+    Have HPUX shadow .............: ${have_shadow_hpux}
+    Have password helper .........: ${have_passwd_helper}
+    Authentication scheme ........: ${AUTH_SCHEME}"
 
 if test "x$need_setuid" = "xyes" -a "x$have_pam" != "xyes" ; then
 echo \
-"        Need setuid dialog:       yes
+"    Need setuid dialog ...........: yes
 "
 else
 echo \
-"        Need setuid dialog:       no
+"    Need setuid dialog ...........: no
 "
 fi
 


### PR DESCRIPTION
sample output:
```
Configure summary:

    mate-screensaver 1.26.0
    =======================

    prefix .......................: /usr
    exec_prefix ..................: ${prefix}
    libdir .......................: /usr/lib64
    bindir .......................: /usr/bin
    sysconfdir ...................: /etc
    localstatedir ................: /var
    datadir ......................: ${prefix}/share
    PAM prefix ...................: /etc
    source code location .........: .
    compiler .....................: gcc
    cflags .......................: 
    Warning flags ................: -Wall -Wmissing-prototypes
    Base libs ....................: -lX11 -lXss -ldbus-glib-1 -ldbus-1 -lmate-desktop-2 -lgtk-3 -lgdk-3 -lpangocairo-1.0 -lpango-1.0 -lharfbuzz -latk-1.0 -lcairo-gobject -lcairo -lgdk_pixbuf-2.0 -lstartup-notification-1 -lmate-menu -lgio-2.0 -lgobject-2.0 -lglib-2.0 
    Extension libs ...............:   -lSM -lICE -lXext -lX11  -lXss -lXxf86vm
    Maintainer mode ..............: yes
    Docs enabled .................: no

    GL ...........................: yes

    Screen locking enabled .......: yes
    Show keyboard indicator ......: yes
    systemd support ..............: yes
    elogind support ..............: no
    ConsoleKit support ...........: yes
    libnotify support ............: yes
    PAM support ..................: yes
    bsd_auth(3) support ..........: no
    Have shadow passwords ........: yes
    Have adjunct shadow ..........: no
    Have enhanced shadow .........: no
    Have HPUX shadow .............: no
    Have password helper .........: no
    Authentication scheme ........: pam
    Need setuid dialog ...........: no


Now type `make' to compile mate-screensaver
```