### PR TITLE
Fix build warnings about missing field initializer

### DIFF
--- a/savers/floaters.c
+++ b/savers/floaters.c
@@ -1149,7 +1149,7 @@ main (int   argc,
 		  N_("The initial size and position of window"), N_("WIDTHxHEIGHT+X+Y") },
 		{ G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_FILENAME_ARRAY, &filenames,
 		  N_("The source image to use"), NULL },
-		{NULL}
+		{ NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL }
 	};
 
 	bindtextdomain (GETTEXT_PACKAGE, MATELOCALEDIR);

--- a/savers/slideshow.c
+++ b/savers/slideshow.c
@@ -67,7 +67,7 @@ main (int argc, char **argv)
 			"no-stretch", 0, 0, G_OPTION_ARG_NONE, &no_stretch,
 			N_("Do not try to stretch images on screen"), NULL
 		},
-		{ NULL }
+		{ NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL }
 	};
 
 	bindtextdomain (GETTEXT_PACKAGE, MATELOCALEDIR);

--- a/src/mate-screensaver-command.c
+++ b/src/mate-screensaver-command.c
@@ -108,7 +108,7 @@ static GOptionEntry entries [] =
 		"version", 'V', 0, G_OPTION_ARG_NONE, &do_version,
 		N_("Version of this application"), NULL
 	},
-	{ NULL }
+	{ NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL }
 };
 
 static GMainLoop *loop = NULL;

--- a/src/mate-screensaver-dialog.c
+++ b/src/mate-screensaver-dialog.c
@@ -62,7 +62,7 @@ static GOptionEntry entries[] = {
 	{"enable-switch", 0, 0, G_OPTION_ARG_NONE, &enable_switch, N_("Show the switch user button"), NULL},
 	{"status-message", 0, 0, G_OPTION_ARG_STRING, &status_message, N_("Message to show in the dialog"), N_("MESSAGE")},
 	{"away-message", 0, 0, G_OPTION_ARG_STRING, &away_message, N_("Not used"), N_("MESSAGE")},
-	{NULL}
+	{NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL}
 };
 
 static char* get_id_string(GtkWidget* widget)

--- a/src/mate-screensaver.c
+++ b/src/mate-screensaver.c
@@ -56,7 +56,7 @@ int main(int argc, char **argv)
 		{"version", 0, 0, G_OPTION_ARG_NONE, &show_version, N_("Version of this application"), NULL},
 		{"no-daemon", 0, 0, G_OPTION_ARG_NONE, &no_daemon, N_("Don't become a daemon"), NULL},
 		{"debug", 0, 0, G_OPTION_ARG_NONE, &debug, N_("Enable debugging code"), NULL},
-		{NULL}
+		{NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL}
 	};
 
 	#ifdef ENABLE_NLS


### PR DESCRIPTION
```
mate-screensaver.c:59:8: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
                {NULL}
                     ^
--
mate-screensaver-command.c:111:9: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
        { NULL }
               ^
--
mate-screensaver-dialog.c:65:7: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
        {NULL}
             ^
--
floaters.c:1152:8: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
                {NULL}
                     ^
--
slideshow.c:70:10: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
                { NULL }
                       ^
```