### PR TITLE
gs-theme-manager: reload on menu_tree changed

### DIFF
--- a/src/gs-theme-manager.c
+++ b/src/gs-theme-manager.c
@@ -393,11 +393,25 @@ get_themes_tree (void)
 }
 
 static void
+on_applications_changed (MateMenuTree *menu_tree)
+{
+	GError *error = NULL;
+
+	if (!matemenu_tree_load_sync (menu_tree, &error)) {
+		g_debug ("Load matemenu tree got error: %s\n", error->message);
+		g_error_free (error);
+	}
+}
+
+static void
 gs_theme_manager_init (GSThemeManager *theme_manager)
 {
 	theme_manager->priv = gs_theme_manager_get_instance_private (theme_manager);
 
 	theme_manager->priv->menu_tree = get_themes_tree ();
+	g_signal_connect (theme_manager->priv->menu_tree, "changed",
+	                  G_CALLBACK (on_applications_changed),
+	                  NULL);
 }
 
 static void


### PR DESCRIPTION
closes #263
```C
  /**
   * MateMenuTree:changed:
   *
   * This signal is emitted when applications are added, removed, or
   * upgraded.  But note the new data will only be visible after
   * matemenu_tree_load_sync() or a variant thereof is invoked.
   */
  matemenu_tree_signals[CHANGED] =
      g_signal_new ("changed",
                    G_TYPE_FROM_CLASS (klass),
                    G_SIGNAL_RUN_LAST,
                    0,
                    NULL, NULL,
                    g_cclosure_marshal_VOID__VOID,
                    G_TYPE_NONE, 0);
```