### PR TITLE
Fix some -Wshorten-64-to-32 warnings

### DIFF
--- a/savers/xdg-user-dir-lookup.c
+++ b/savers/xdg-user-dir-lookup.c
@@ -40,7 +40,6 @@ xdg_user_dir_lookup (const char *type)
 	char buffer[512];
 	char *user_dir;
 	char *p, *d;
-	int len;
 	int relative;
 
 	home_dir = getenv ("HOME");
@@ -71,8 +70,8 @@ xdg_user_dir_lookup (const char *type)
 	while (fgets (buffer, sizeof (buffer), file))
 	{
 		/* Remove newline at end */
-		len = strlen (buffer);
-		if (len > 0 && buffer[len-1] == '\n')
+		size_t len = strlen (buffer);
+		if (len != 0 && buffer[len-1] == '\n')
 			buffer[len-1] = 0;
 
 		p = buffer;

--- a/src/gs-lock-plug.c
+++ b/src/gs-lock-plug.c
@@ -1723,8 +1723,8 @@ expand_string (const char *text)
 	GString       *str;
 	const char    *p;
 	char          *username;
-	int            i;
-	int            n_chars;
+	glong          i;
+	glong          n_chars;
 	struct utsname name;
 
 	str = g_string_sized_new (strlen (text));

--- a/src/gs-watcher-x11.c
+++ b/src/gs-watcher-x11.c
@@ -89,11 +89,11 @@ remove_watchdog_timer (GSWatcher *watcher)
 
 static void
 add_watchdog_timer (GSWatcher *watcher,
-                    glong      timeout)
+                    guint      timeout)
 {
 	watcher->priv->watchdog_timer_id = g_timeout_add (timeout,
-	                                   (GSourceFunc)watchdog_timer,
-	                                   watcher);
+	                                                  (GSourceFunc)watchdog_timer,
+	                                                  watcher);
 }
 
 static void

--- a/src/gs-window-x11.c
+++ b/src/gs-window-x11.c
@@ -615,11 +615,11 @@ remove_watchdog_timer (GSWindow *window)
 
 static void
 add_watchdog_timer (GSWindow *window,
-                    glong     timeout)
+                    guint     timeout)
 {
 	window->priv->watchdog_timer_id = g_timeout_add (timeout,
-	                                  (GSourceFunc)watchdog_timer,
-	                                  window);
+	                                                 (GSourceFunc)watchdog_timer,
+	                                                 window);
 }
 
 static void


### PR DESCRIPTION
```
CFLAGS="-Wconversion -Wunused-macros -Wunused-parameter" CC=clang ./autogen.sh --prefix=/usr --enable-debug --enable-compile-warnings=maximum && make &> make.log
```
```
gs-lock-plug.c:1733:12: warning: implicit conversion loses integer precision: 'glong' (aka 'long') to 'int' [-Wshorten-64-to-32]
gs-watcher-x11.c:94:52: warning: implicit conversion loses integer precision: 'glong' (aka 'long') to 'guint' (aka 'unsigned int') [-Wshorten-64-to-32]
gs-window-x11.c:620:51: warning: implicit conversion loses integer precision: 'glong' (aka 'long') to 'guint' (aka 'unsigned int') [-Wshorten-64-to-32]
xdg-user-dir-lookup.c:74:9: warning: implicit conversion loses integer precision: 'unsigned long' to 'int' [-Wshorten-64-to-32]
```