### PR TITLE
Sign conversion bool to guint

### DIFF
--- a/savers/floaters.c
+++ b/savers/floaters.c
@@ -825,8 +825,8 @@ screen_saver_new (GtkWidget       *drawing_area,
 	screen_saver->floaters = NULL;
 	screen_saver->max_floater_count = max_floater_count;
 
-	screen_saver->should_show_paths = should_show_paths;
-	screen_saver->should_do_rotations = should_do_rotations;
+	screen_saver->should_show_paths = (should_show_paths != FALSE);
+	screen_saver->should_do_rotations = (should_do_rotations != FALSE);
 
 	screen_saver_get_initial_state (screen_saver);
 

--- a/src/gs-fade.c
+++ b/src/gs-fade.c
@@ -272,7 +272,7 @@ gs_fade_set_enabled (GSFade  *fade,
 
 	if (fade->priv->enabled != enabled)
 	{
-		fade->priv->enabled = enabled;
+		fade->priv->enabled = (enabled != FALSE);
 	}
 }
 

--- a/src/gs-grab-x11.c
+++ b/src/gs-grab-x11.c
@@ -149,8 +149,8 @@ gs_grab_get (GSGrab     *grab,
 		                           (gpointer *) &grab->priv->grab_window);
 
 		grab->priv->grab_display = display;
-		grab->priv->no_pointer_grab = no_pointer_grab;
-		grab->priv->hide_cursor = hide_cursor;
+		grab->priv->no_pointer_grab = (no_pointer_grab != FALSE);
+		grab->priv->hide_cursor = (hide_cursor != FALSE);
 	}
 
 	g_object_unref (G_OBJECT (cursor));

--- a/src/gs-listener-dbus.c
+++ b/src/gs-listener-dbus.c
@@ -363,7 +363,7 @@ gs_listener_set_throttle (GSListener *listener,
 	{
 		gs_debug ("Changing throttle status: %d", throttled);
 
-		listener->priv->throttled = throttled;
+		listener->priv->throttled = (throttled != FALSE);
 
 		g_signal_emit (listener, signals [THROTTLE_CHANGED], 0, throttled);
 	}
@@ -390,7 +390,7 @@ static gboolean
 listener_set_session_idle_internal (GSListener *listener,
                                     gboolean    idle)
 {
-	listener->priv->session_idle = idle;
+	listener->priv->session_idle = (idle != FALSE);
 
 	if (idle)
 	{
@@ -408,7 +408,7 @@ static gboolean
 listener_set_active_internal (GSListener *listener,
                               gboolean    active)
 {
-	listener->priv->active = active;
+	listener->priv->active = (active != FALSE);
 
 	/* if idle not in sync with active, change it */
 	if (listener->priv->session_idle != active)
@@ -496,7 +496,7 @@ gs_listener_set_session_idle (GSListener *listener,
 		}
 	}
 
-	listener->priv->session_idle = idle;
+	listener->priv->session_idle = (idle != FALSE);
 	res = listener_check_activation (listener);
 
 	/* if activation fails then don't set idle */
@@ -541,7 +541,7 @@ gs_listener_set_activation_enabled (GSListener *listener,
 
 	if (listener->priv->activation_enabled != enabled)
 	{
-		listener->priv->activation_enabled = enabled;
+		listener->priv->activation_enabled = (enabled != FALSE);
 	}
 }
 

--- a/src/gs-manager.c
+++ b/src/gs-manager.c
@@ -418,7 +418,7 @@ gs_manager_set_throttled (GSManager *manager,
 	{
 		GSList *l;
 
-		manager->priv->throttled = throttled;
+		manager->priv->throttled = (throttled != FALSE);
 
 		if (! manager->priv->dialog_up)
 		{
@@ -462,7 +462,7 @@ gs_manager_set_lock_active (GSManager *manager,
 	{
 		GSList *l;
 
-		manager->priv->lock_active = lock_active;
+		manager->priv->lock_active = (lock_active != FALSE);
 		for (l = manager->priv->windows; l; l = l->next)
 		{
 			gs_window_set_lock_enabled (l->data, lock_active);
@@ -495,7 +495,7 @@ gs_manager_set_lock_enabled (GSManager *manager,
 
 	if (manager->priv->lock_enabled != lock_enabled)
 	{
-		manager->priv->lock_enabled = lock_enabled;
+		manager->priv->lock_enabled = (lock_enabled != FALSE);
 	}
 }
 
@@ -509,7 +509,7 @@ gs_manager_set_logout_enabled (GSManager *manager,
 	{
 		GSList *l;
 
-		manager->priv->logout_enabled = logout_enabled;
+		manager->priv->logout_enabled = (logout_enabled != FALSE);
 		for (l = manager->priv->windows; l; l = l->next)
 		{
 			gs_window_set_logout_enabled (l->data, logout_enabled);
@@ -527,7 +527,7 @@ gs_manager_set_keyboard_enabled (GSManager *manager,
 	{
 		GSList *l;
 
-		manager->priv->keyboard_enabled = enabled;
+		manager->priv->keyboard_enabled = (enabled != FALSE);
 		for (l = manager->priv->windows; l; l = l->next)
 		{
 			gs_window_set_keyboard_enabled (l->data, enabled);
@@ -545,7 +545,7 @@ gs_manager_set_user_switch_enabled (GSManager *manager,
 	{
 		GSList *l;
 
-		manager->priv->user_switch_enabled = user_switch_enabled;
+		manager->priv->user_switch_enabled = (user_switch_enabled != FALSE);
 		for (l = manager->priv->windows; l; l = l->next)
 		{
 			gs_window_set_user_switch_enabled (l->data, user_switch_enabled);

--- a/src/gs-prefs.c
+++ b/src/gs-prefs.c
@@ -215,35 +215,35 @@ static void
 _gs_prefs_set_idle_activation_enabled (GSPrefs *prefs,
                                        gboolean value)
 {
-	prefs->idle_activation_enabled = value;
+	prefs->idle_activation_enabled = (value != FALSE);
 }
 
 static void
 _gs_prefs_set_lock_enabled (GSPrefs *prefs,
                             gboolean value)
 {
-	prefs->lock_enabled = value;
+	prefs->lock_enabled = (value != FALSE);
 }
 
 static void
 _gs_prefs_set_lock_disabled (GSPrefs *prefs,
                              gboolean value)
 {
-	prefs->lock_disabled = value;
+	prefs->lock_disabled = (value != FALSE);
 }
 
 static void
 _gs_prefs_set_user_switch_disabled (GSPrefs *prefs,
                                     gboolean value)
 {
-	prefs->user_switch_disabled = value;
+	prefs->user_switch_disabled = (value != FALSE);
 }
 
 static void
 _gs_prefs_set_keyboard_enabled (GSPrefs *prefs,
                                 gboolean value)
 {
-	prefs->keyboard_enabled = value;
+	prefs->keyboard_enabled = (value != FALSE);
 }
 
 static void
@@ -265,14 +265,14 @@ static void
 _gs_prefs_set_status_message_enabled (GSPrefs  *prefs,
                                       gboolean  enabled)
 {
-	prefs->status_message_enabled = enabled;
+	prefs->status_message_enabled = (enabled != FALSE);
 }
 
 static void
 _gs_prefs_set_logout_enabled (GSPrefs *prefs,
                               gboolean value)
 {
-	prefs->logout_enabled = value;
+	prefs->logout_enabled = (value != FALSE);
 }
 
 static void
@@ -309,7 +309,7 @@ static void
 _gs_prefs_set_user_switch_enabled (GSPrefs *prefs,
                                    gboolean value)
 {
-	prefs->user_switch_enabled = value;
+	prefs->user_switch_enabled = (value != FALSE);
 }
 
 static void

--- a/src/gs-prefs.c
+++ b/src/gs-prefs.c
@@ -56,6 +56,15 @@ static void gs_prefs_finalize   (GObject      *object);
 #define KEY_KEYBOARD_COMMAND "embedded-keyboard-command"
 #define KEY_STATUS_MESSAGE_ENABLED "status-message-enabled"
 
+#define _gs_prefs_set_idle_activation_enabled(x,y) ((x)->idle_activation_enabled = ((y) != FALSE))
+#define _gs_prefs_set_lock_enabled(x,y) ((x)->lock_enabled = ((y) != FALSE))
+#define _gs_prefs_set_lock_disabled(x,y) ((x)->lock_disabled = ((y) != FALSE))
+#define _gs_prefs_set_user_switch_disabled(x,y) ((x)->user_switch_disabled = ((y) != FALSE))
+#define _gs_prefs_set_keyboard_enabled(x,y) ((x)->keyboard_enabled = ((y) != FALSE))
+#define _gs_prefs_set_status_message_enabled(x,y) ((x)->status_message_enabled = ((y) != FALSE))
+#define _gs_prefs_set_logout_enabled(x,y) ((x)->logout_enabled = ((y) != FALSE))
+#define _gs_prefs_set_user_switch_enabled(x,y) ((x)->user_switch_enabled = ((y) != FALSE))
+
 struct GSPrefsPrivate
 {
 	GSettings *settings;
@@ -212,41 +221,6 @@ _gs_prefs_set_themes (GSPrefs *prefs,
 }
 
 static void
-_gs_prefs_set_idle_activation_enabled (GSPrefs *prefs,
-                                       gboolean value)
-{
-	prefs->idle_activation_enabled = (value != FALSE);
-}
-
-static void
-_gs_prefs_set_lock_enabled (GSPrefs *prefs,
-                            gboolean value)
-{
-	prefs->lock_enabled = (value != FALSE);
-}
-
-static void
-_gs_prefs_set_lock_disabled (GSPrefs *prefs,
-                             gboolean value)
-{
-	prefs->lock_disabled = (value != FALSE);
-}
-
-static void
-_gs_prefs_set_user_switch_disabled (GSPrefs *prefs,
-                                    gboolean value)
-{
-	prefs->user_switch_disabled = (value != FALSE);
-}
-
-static void
-_gs_prefs_set_keyboard_enabled (GSPrefs *prefs,
-                                gboolean value)
-{
-	prefs->keyboard_enabled = (value != FALSE);
-}
-
-static void
 _gs_prefs_set_keyboard_command (GSPrefs    *prefs,
                                 const char *value)
 {
@@ -259,20 +233,6 @@ _gs_prefs_set_keyboard_command (GSPrefs    *prefs,
 
 		prefs->keyboard_command = g_strdup (value);
 	}
-}
-
-static void
-_gs_prefs_set_status_message_enabled (GSPrefs  *prefs,
-                                      gboolean  enabled)
-{
-	prefs->status_message_enabled = (enabled != FALSE);
-}
-
-static void
-_gs_prefs_set_logout_enabled (GSPrefs *prefs,
-                              gboolean value)
-{
-	prefs->logout_enabled = (value != FALSE);
 }
 
 static void
@@ -303,13 +263,6 @@ _gs_prefs_set_logout_timeout (GSPrefs *prefs,
 		value = 480;
 
 	prefs->logout_timeout = value * 60000;
-}
-
-static void
-_gs_prefs_set_user_switch_enabled (GSPrefs *prefs,
-                                   gboolean value)
-{
-	prefs->user_switch_enabled = (value != FALSE);
 }
 
 static void

--- a/src/gs-watcher-x11.c
+++ b/src/gs-watcher-x11.c
@@ -203,7 +203,7 @@ _gs_watcher_set_session_idle_notice (GSWatcher *watcher,
 		{
 			gs_debug ("Changing idle notice state: %d", in_effect);
 
-			watcher->priv->idle_notice = in_effect;
+			watcher->priv->idle_notice = (in_effect != FALSE);
 		}
 		else
 		{
@@ -230,7 +230,7 @@ _gs_watcher_set_session_idle (GSWatcher *watcher,
 		{
 			gs_debug ("Changing idle state: %d", is_idle);
 
-			watcher->priv->idle = is_idle;
+			watcher->priv->idle = (is_idle != FALSE);
 		}
 		else
 		{
@@ -269,7 +269,7 @@ _gs_watcher_set_active_internal (GSWatcher *watcher,
 		/* reset state */
 		_gs_watcher_reset_state (watcher);
 
-		watcher->priv->active = active;
+		watcher->priv->active = (active != FALSE);
 	}
 
 	return TRUE;
@@ -309,7 +309,7 @@ gs_watcher_set_enabled (GSWatcher *watcher,
 	{
 		gboolean is_active = gs_watcher_get_active (watcher);
 
-		watcher->priv->enabled = enabled;
+		watcher->priv->enabled = (enabled != FALSE);
 
 		/* if we are disabling the watcher and we are
 		   active shut it down */

--- a/src/gs-window-x11.c
+++ b/src/gs-window-x11.c
@@ -1535,7 +1535,7 @@ window_set_dialog_up (GSWindow *window,
 		return;
 	}
 
-	window->priv->dialog_up = dialog_up;
+	window->priv->dialog_up = (dialog_up != FALSE);
 	g_object_notify (G_OBJECT (window), "dialog-up");
 }
 
@@ -1819,7 +1819,7 @@ gs_window_set_lock_enabled (GSWindow *window,
 		return;
 	}
 
-	window->priv->lock_enabled = lock_enabled;
+	window->priv->lock_enabled = (lock_enabled != FALSE);
 	g_object_notify (G_OBJECT (window), "lock-enabled");
 }
 
@@ -1837,7 +1837,7 @@ gs_window_set_keyboard_enabled (GSWindow *window,
 {
 	g_return_if_fail (GS_IS_WINDOW (window));
 
-	window->priv->keyboard_enabled = enabled;
+	window->priv->keyboard_enabled = (enabled != FALSE);
 }
 
 void
@@ -1864,7 +1864,7 @@ gs_window_set_logout_enabled (GSWindow *window,
 {
 	g_return_if_fail (GS_IS_WINDOW (window));
 
-	window->priv->logout_enabled = logout_enabled;
+	window->priv->logout_enabled = (logout_enabled != FALSE);
 }
 
 void
@@ -1873,7 +1873,7 @@ gs_window_set_user_switch_enabled (GSWindow *window,
 {
 	g_return_if_fail (GS_IS_WINDOW (window));
 
-	window->priv->user_switch_enabled = user_switch_enabled;
+	window->priv->user_switch_enabled = (user_switch_enabled != FALSE);
 }
 
 void
@@ -2283,7 +2283,7 @@ window_set_obscured (GSWindow *window,
 		return;
 	}
 
-	window->priv->obscured = obscured;
+	window->priv->obscured = (obscured != FALSE);
 	g_object_notify (G_OBJECT (window), "obscured");
 }
 


### PR DESCRIPTION
```
gs-listener-dbus.c:366:31: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
                listener->priv->throttled = throttled;
                                          ~ ^~~~~~~~~
gs-listener-dbus.c:393:33: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
        listener->priv->session_idle = idle;
                                     ~ ^~~~
gs-listener-dbus.c:411:27: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
        listener->priv->active = active;
                               ~ ^~~~~~
gs-listener-dbus.c:499:33: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
        listener->priv->session_idle = idle;
                                     ~ ^~~~
gs-listener-dbus.c:544:40: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
                listener->priv->activation_enabled = enabled;
                                                   ~ ^~~~~~~
--
gs-watcher-x11.c:206:33: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
                        watcher->priv->idle_notice = in_effect;
                                                   ~ ^~~~~~~~~
gs-watcher-x11.c:233:26: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
                        watcher->priv->idle = is_idle;
                                            ~ ^~~~~~~
gs-watcher-x11.c:272:27: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
                watcher->priv->active = active;
                                      ~ ^~~~~~
gs-watcher-x11.c:312:28: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
                watcher->priv->enabled = enabled;
                                       ~ ^~~~~~~
--
gs-manager.c:421:30: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
                manager->priv->throttled = throttled;
                                         ~ ^~~~~~~~~
gs-manager.c:465:32: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
                manager->priv->lock_active = lock_active;
                                           ~ ^~~~~~~~~~~
gs-manager.c:498:33: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
                manager->priv->lock_enabled = lock_enabled;
                                            ~ ^~~~~~~~~~~~
gs-manager.c:512:35: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
                manager->priv->logout_enabled = logout_enabled;
                                              ~ ^~~~~~~~~~~~~~
gs-manager.c:530:37: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
                manager->priv->keyboard_enabled = enabled;
                                                ~ ^~~~~~~
gs-manager.c:548:40: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
                manager->priv->user_switch_enabled = user_switch_enabled;
                                                   ~ ^~~~~~~~~~~~~~~~~~~
--
gs-window-x11.c:1538:28: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
        window->priv->dialog_up = dialog_up;
                                ~ ^~~~~~~~~
--
gs-window-x11.c:1822:31: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
        window->priv->lock_enabled = lock_enabled;
                                   ~ ^~~~~~~~~~~~
gs-window-x11.c:1840:35: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
        window->priv->keyboard_enabled = enabled;
                                       ~ ^~~~~~~
gs-window-x11.c:1867:33: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
        window->priv->logout_enabled = logout_enabled;
                                     ~ ^~~~~~~~~~~~~~
gs-window-x11.c:1876:38: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
        window->priv->user_switch_enabled = user_switch_enabled;
                                          ~ ^~~~~~~~~~~~~~~~~~~
--
gs-window-x11.c:2286:27: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
        window->priv->obscured = obscured;
                               ~ ^~~~~~~~
--
gs-prefs.c:218:35: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
        prefs->idle_activation_enabled = value;
                                       ~ ^~~~~
gs-prefs.c:225:24: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
        prefs->lock_enabled = value;
                            ~ ^~~~~
gs-prefs.c:232:25: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
        prefs->lock_disabled = value;
                             ~ ^~~~~
gs-prefs.c:239:32: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
        prefs->user_switch_disabled = value;
                                    ~ ^~~~~
gs-prefs.c:246:28: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
        prefs->keyboard_enabled = value;
                                ~ ^~~~~
gs-prefs.c:268:34: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
        prefs->status_message_enabled = enabled;
                                      ~ ^~~~~~~
gs-prefs.c:275:26: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
        prefs->logout_enabled = value;
                              ~ ^~~~~
--
gs-prefs.c:312:31: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
        prefs->user_switch_enabled = value;
                                   ~ ^~~~~
--
gs-grab-x11.c:152:33: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
                grab->priv->no_pointer_grab = no_pointer_grab;
                                            ~ ^~~~~~~~~~~~~~~
gs-grab-x11.c:153:29: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
                grab->priv->hide_cursor = hide_cursor;
                                        ~ ^~~~~~~~~~~
--
gs-fade.c:275:25: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
                fade->priv->enabled = enabled;
                                    ~ ^~~~~~~
--
floaters.c:828:36: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
        screen_saver->should_show_paths = should_show_paths;
                                        ~ ^~~~~~~~~~~~~~~~~
floaters.c:829:38: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
        screen_saver->should_do_rotations = should_do_rotations;
                                          ~ ^~~~~~~~~~~~~~~~~~~
```