### PR TITLE
mate-screensaver-preferences: fix memory leak

### DIFF
--- a/src/mate-screensaver-preferences.c
+++ b/src/mate-screensaver-preferences.c
@@ -663,19 +663,20 @@ separator_func (GtkTreeModel *model,
                 GtkTreeIter  *iter,
                 gpointer      data)
 {
-	int   column = GPOINTER_TO_INT (data);
-	char *text;
+	int       column = GPOINTER_TO_INT (data);
+	gboolean  res = FALSE;
+	char     *text;
 
 	gtk_tree_model_get (model, iter, column, &text, -1);
 
 	if (text != NULL && strcmp (text, "__separator") == 0)
 	{
-		return TRUE;
+		res = TRUE;
 	}
 
 	g_free (text);
 
-	return FALSE;
+	return res;
 }
 
 static void


### PR DESCRIPTION
```
Direct leak of 72 byte(s) in 6 object(s) allocated from:
    #0 0x7f1b67c5793f in __interceptor_malloc (/lib64/libasan.so.6+0xae93f)
    #1 0x7f1b666c84df in g_malloc ../glib/gmem.c:106
    #2 0x7f1b666c8822 in g_malloc_n ../glib/gmem.c:344
    #3 0x7f1b666eae35 in g_strdup ../glib/gstrfuncs.c:361
    #4 0x7f1b6680a016 in value_lcopy_string ../gobject/gvaluetypes.c:313
    #5 0x7f1b673228fc in gtk_tree_model_get_valist ../gtk/gtktreemodel.c:1812
    #6 0x7f1b6732234b in gtk_tree_model_get ../gtk/gtktreemodel.c:1774
    #7 0x408f82 in separator_func /home/robert/builddir.gcc/mate-screensaver/src/mate-screensaver-preferences.c:669
    #8 0x7f1b6734c374 in row_is_separator ../gtk/gtktreeview.c:3113
    #9 0x7f1b6735cfee in gtk_tree_view_bin_draw ../gtk/gtktreeview.c:5177
    #10 0x7f1b6735c998 in draw_bin ../gtk/gtktreeview.c:5638
    #11 0x7f1b6720466d in _gtk_pixel_cache_repaint ../gtk/gtkpixelcache.c:358
    #12 0x7f1b67203c4d in _gtk_pixel_cache_draw ../gtk/gtkpixelcache.c:448
    #13 0x7f1b673572dc in gtk_tree_view_draw ../gtk/gtktreeview.c:5681
    #14 0x7f1b67381e37 in gtk_widget_draw_internal ../gtk/gtkwidget.c:7084
    #15 0x7f1b6702deff in gtk_container_propagate_draw ../gtk/gtkcontainer.c:3854
    #16 0x7f1b6702e94e in gtk_container_draw ../gtk/gtkcontainer.c:3674
    #17 0x7f1b6725451a in gtk_scrolled_window_render ../gtk/gtkscrolledwindow.c:2119
    #18 0x7f1b6703989d in gtk_css_custom_gadget_draw ../gtk/gtkcsscustomgadget.c:159
    #19 0x7f1b6703fcc1 in gtk_css_gadget_draw ../gtk/gtkcssgadget.c:885
    #20 0x7f1b6724de49 in gtk_scrolled_window_draw ../gtk/gtkscrolledwindow.c:3050
    #21 0x7f1b67381e37 in gtk_widget_draw_internal ../gtk/gtkwidget.c:7084
    #22 0x7f1b6702deff in gtk_container_propagate_draw ../gtk/gtkcontainer.c:3854
    #23 0x7f1b6702e94e in gtk_container_draw ../gtk/gtkcontainer.c:3674
    #24 0x7f1b6711250e in gtk_grid_render ../gtk/gtkgrid.c:1711
    #25 0x7f1b6703989d in gtk_css_custom_gadget_draw ../gtk/gtkcsscustomgadget.c:159
    #26 0x7f1b6703fcc1 in gtk_css_gadget_draw ../gtk/gtkcssgadget.c:885
    #27 0x7f1b671118d9 in gtk_grid_draw ../gtk/gtkgrid.c:1720
    #28 0x7f1b67381e37 in gtk_widget_draw_internal ../gtk/gtkwidget.c:7084
    #29 0x7f1b6702deff in gtk_container_propagate_draw ../gtk/gtkcontainer.c:3854

Direct leak of 12 byte(s) in 1 object(s) allocated from:
    #0 0x7f1b67c5793f in __interceptor_malloc (/lib64/libasan.so.6+0xae93f)
    #1 0x7f1b666c84df in g_malloc ../glib/gmem.c:106
    #2 0x7f1b666c8822 in g_malloc_n ../glib/gmem.c:344
    #3 0x7f1b666eae35 in g_strdup ../glib/gstrfuncs.c:361
    #4 0x7f1b6680a016 in value_lcopy_string ../gobject/gvaluetypes.c:313
    #5 0x7f1b673228fc in gtk_tree_model_get_valist ../gtk/gtktreemodel.c:1812
    #6 0x7f1b6732234b in gtk_tree_model_get ../gtk/gtktreemodel.c:1774
    #7 0x408f82 in separator_func /home/robert/builddir.gcc/mate-screensaver/src/mate-screensaver-preferences.c:669
    #8 0x7f1b6734c374 in row_is_separator ../gtk/gtktreeview.c:3113
    #9 0x7f1b6735b168 in validate_row ../gtk/gtktreeview.c:6368
    #10 0x7f1b67369d1a in validate_visible_area ../gtk/gtktreeview.c:6783
    #11 0x7f1b67341445 in do_presize_handler ../gtk/gtktreeview.c:7102
    #12 0x7f1b67368df4 in presize_handler_callback ../gtk/gtktreeview.c:7133
    #13 0x7f1b6737d7ae in gtk_widget_on_frame_clock_update ../gtk/gtkwidget.c:5287
    #14 0x7f1b667d918f in g_cclosure_marshal_VOID__VOID ../gobject/gmarshal.c:117
    #15 0x7f1b667d5465 in g_closure_invoke ../gobject/gclosure.c:830
    #16 0x7f1b667f6202 in signal_emit_unlocked_R ../gobject/gsignal.c:3744
    #17 0x7f1b667f7b5a in g_signal_emit_valist ../gobject/gsignal.c:3497
    #18 0x7f1b667f834e in g_signal_emit ../gobject/gsignal.c:3554
    #19 0x7f1b66ddc69e in _gdk_frame_clock_emit_update ../gdk/gdkframeclock.c:645
    #20 0x7f1b66ddde56 in gdk_frame_clock_paint_idle ../gdk/gdkframeclockidle.c:547
    #21 0x7f1b66dbdcd6 in gdk_threads_dispatch ../gdk/gdk.c:769
    #22 0x7f1b666b9d26 in g_timeout_dispatch ../glib/gmain.c:4965
    #23 0x7f1b666bf116 in g_main_dispatch ../glib/gmain.c:3413
    #24 0x7f1b666bef5f in g_main_context_dispatch ../glib/gmain.c:4131
    #25 0x7f1b666bf481 in g_main_context_iterate ../glib/gmain.c:4207
    #26 0x7f1b666bf9a2 in g_main_loop_run ../glib/gmain.c:4405
    #27 0x7f1b67179935 in gtk_main ../gtk/gtkmain.c:1329
    #28 0x40cb88 in main /home/robert/builddir.gcc/mate-screensaver/src/mate-screensaver-preferences.c:1823
    #29 0x7f1b664aab74 in __libc_start_main (/lib64/libc.so.6+0x27b74)

Direct leak of 12 byte(s) in 1 object(s) allocated from:
    #0 0x7f1b67c5793f in __interceptor_malloc (/lib64/libasan.so.6+0xae93f)
    #1 0x7f1b666c84df in g_malloc ../glib/gmem.c:106
    #2 0x7f1b666c8822 in g_malloc_n ../glib/gmem.c:344
    #3 0x7f1b666eae35 in g_strdup ../glib/gstrfuncs.c:361
    #4 0x7f1b6680a016 in value_lcopy_string ../gobject/gvaluetypes.c:313
    #5 0x7f1b673228fc in gtk_tree_model_get_valist ../gtk/gtktreemodel.c:1812
    #6 0x7f1b6732234b in gtk_tree_model_get ../gtk/gtktreemodel.c:1774
    #7 0x408f82 in separator_func /home/robert/builddir.gcc/mate-screensaver/src/mate-screensaver-preferences.c:669
    #8 0x7f1b6734c374 in row_is_separator ../gtk/gtktreeview.c:3113
    #9 0x7f1b6735b168 in validate_row ../gtk/gtktreeview.c:6368
    #10 0x7f1b6735ab5b in do_validate_rows ../gtk/gtktreeview.c:6988
    #11 0x7f1b67356382 in gtk_tree_view_get_preferred_width ../gtk/gtktreeview.c:2669
    #12 0x7f1b67273fed in gtk_widget_query_size_for_orientation ../gtk/gtksizerequest.c:181
    #13 0x7f1b672731b5 in gtk_widget_compute_size_for_orientation ../gtk/gtksizerequest.c:399
    #14 0x7f1b672730c0 in gtk_widget_get_preferred_width ../gtk/gtksizerequest.c:492
    #15 0x7f1b67252b29 in gtk_scrolled_window_measure ../gtk/gtkscrolledwindow.c:1849
    #16 0x7f1b67039718 in gtk_css_custom_gadget_get_preferred_size ../gtk/gtkcsscustomgadget.c:124
    #17 0x7f1b6703f002 in gtk_css_gadget_get_preferred_size ../gtk/gtkcssgadget.c:683
    #18 0x7f1b6724e745 in gtk_scrolled_window_get_preferred_width ../gtk/gtkscrolledwindow.c:4193
    #19 0x7f1b67273fed in gtk_widget_query_size_for_orientation ../gtk/gtksizerequest.c:181
    #20 0x7f1b672731b5 in gtk_widget_compute_size_for_orientation ../gtk/gtksizerequest.c:399
    #21 0x7f1b672730c0 in gtk_widget_get_preferred_width ../gtk/gtksizerequest.c:492
    #22 0x7f1b67113f29 in compute_request_for_child ../gtk/gtkgrid.c:681
    #23 0x7f1b67113359 in gtk_grid_request_non_spanning ../gtk/gtkgrid.c:723
    #24 0x7f1b671129bc in gtk_grid_request_run ../gtk/gtkgrid.c:1132
    #25 0x7f1b671127f2 in gtk_grid_get_size ../gtk/gtkgrid.c:1438
    #26 0x7f1b6711223b in gtk_grid_measure ../gtk/gtkgrid.c:1569
    #27 0x7f1b67039718 in gtk_css_custom_gadget_get_preferred_size ../gtk/gtkcsscustomgadget.c:124
    #28 0x7f1b6703f002 in gtk_css_gadget_get_preferred_size ../gtk/gtkcssgadget.c:683
    #29 0x7f1b67111705 in gtk_grid_get_preferred_width ../gtk/gtkgrid.c:1490
```