### PR TITLE
gs-auth-pam: failed to remove the event source

### DIFF
--- a/src/gs-auth-pam.c
+++ b/src/gs-auth-pam.c
@@ -669,7 +669,7 @@ gs_auth_pam_verify_user (pam_handle_t *handle,
 	auth_status = GPOINTER_TO_INT (g_thread_join (auth_thread));
 
 out:
-	if (watch_id != 0)
+	if (watch_id != 0 && !thread_done)
 	{
 		g_source_remove (watch_id);
 		watch_id = 0;


### PR DESCRIPTION
Remove runtime warnings such as:
```
(mate-screensaver:35754): GLib-CRITICAL **: 12:08:12.829: Source ID 682 was not found when attempting to remove it
```
fix #190