### PR TITLE
mate-screensaver-preferences: Fix lock-delay time wording

### DIFF
--- a/src/mate-screensaver-preferences.c
+++ b/src/mate-screensaver-preferences.c
@@ -1034,10 +1034,7 @@ format_value_callback_time (GtkScale *scale,
 	gint pad_size;
 
 	/* get the value representation as a string */
-	if (value == 0)
-		time_str = g_strdup (_("Never"));
-	else
-		time_str = time_to_string_text ((long) (value * 60.0));
+	time_str = time_to_string_text ((long) (value * 60.0));
 
 	/* Now, adjust the string so the representation for the bounds are the
 	 * longest ones, and try and adjust the length as smoothly as possible.


### PR DESCRIPTION
The scale controls the delay after which to lock the screen once the screensaver activated, not whether or not it happens -- which has its own checkbox.  So remove the "Never" wording for value 0, which was inherited from an earlier version of the activate-delay scale that is not used anymore (the activate-delay scale is now 1-120, never 0).