### PR TITLE
mate-screensaver-preferences: Simplify mnemonic widget association

### DIFF
--- a/data/mate-screensaver-preferences.ui
+++ b/data/mate-screensaver-preferences.ui
@@ -286,6 +286,7 @@
                         <property name="label" translatable="yes">_Screensaver theme:</property>
                         <property name="use_markup">True</property>
                         <property name="use_underline">True</property>
+                        <property name="mnemonic-widget">savers_treeview</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -411,6 +412,7 @@
                                             <property name="hexpand">False</property>
                                             <property name="label" translatable="yes">Regard the computer as _idle after:</property>
                                             <property name="use_underline">True</property>
+                                            <property name="mnemonic-widget">activate_delay_hscale</property>
                                           </object>
                                           <packing>
                                             <property name="left_attach">0</property>
@@ -443,6 +445,7 @@
                                             <property name="label" translatable="yes">Time before l_ocking:</property>
                                             <property name="tooltip-text" translatable="yes">Delay before locking the screen after the screensaver activated</property>
                                             <property name="use_underline">True</property>
+                                            <property name="mnemonic-widget">lock_delay_hscale</property>
                                           </object>
                                           <packing>
                                             <property name="left_attach">0</property>

--- a/src/mate-screensaver-preferences.c
+++ b/src/mate-screensaver-preferences.c
@@ -1621,7 +1621,6 @@ init_capplet (void)
 	GtkWidget *list_scroller;
 	GtkWidget *activate_delay_hscale;
 	GtkWidget *lock_delay_hscale;
-	GtkWidget *label;
 	GtkWidget *enabled_checkbox;
 	GtkWidget *lock_checkbox;
 	GtkWidget *root_warning_label;
@@ -1681,13 +1680,6 @@ init_capplet (void)
 	fullscreen_preview_previous = GTK_WIDGET (gtk_builder_get_object (builder, "fullscreen_preview_previous_button"));
 	fullscreen_preview_next = GTK_WIDGET (gtk_builder_get_object (builder, "fullscreen_preview_next_button"));
 	picture_filename = GTK_WIDGET (gtk_builder_get_object (builder, "picture_filename"));
-
-	label              = GTK_WIDGET (gtk_builder_get_object (builder, "activate_delay_label"));
-	gtk_label_set_mnemonic_widget (GTK_LABEL (label), activate_delay_hscale);
-	label              = GTK_WIDGET (gtk_builder_get_object (builder, "lock_delay_label"));
-	gtk_label_set_mnemonic_widget (GTK_LABEL (label), lock_delay_hscale);
-	label              = GTK_WIDGET (gtk_builder_get_object (builder, "savers_label"));
-	gtk_label_set_mnemonic_widget (GTK_LABEL (label), treeview);
 
 	gtk_widget_set_no_show_all (root_warning_label, TRUE);
 	widget_set_best_visual (preview);


### PR DESCRIPTION
Instead of doing the binding in the code, do it in the UI file.

This should not change anything but cleaning up the code a bit.