### PR TITLE
Fix mate-screensaver may not respond on logind dbus commands

### DIFF
--- a/src/gs-listener-dbus.c
+++ b/src/gs-listener-dbus.c
@@ -2483,6 +2483,7 @@ query_session_id (GSListener *listener)
 	DBusError       error;
 	DBusMessageIter reply_iter;
 	char           *ssid;
+	const char* auto_session_id;
 
 	if (listener->priv->system_connection == NULL)
 	{
@@ -2498,8 +2499,9 @@ query_session_id (GSListener *listener)
 	if (listener->priv->have_systemd) {
 		dbus_uint32_t pid = getpid();
 
+		/* first try to get session D-bus path by PID */
 		message = dbus_message_new_method_call (SYSTEMD_LOGIND_SERVICE,
-		                                        SYSTEMD_LOGIND_PATH,
+							SYSTEMD_LOGIND_PATH,
 							SYSTEMD_LOGIND_INTERFACE,
 							"GetSessionByPID");
 		if (message == NULL)
@@ -2519,22 +2521,66 @@ query_session_id (GSListener *listener)
 		/* FIXME: use async? */
 		reply = dbus_connection_send_with_reply_and_block (listener->priv->system_connection,
 			message,
-			-1, &error);
+			-1,
+			&error);
 		dbus_message_unref (message);
 
-		if (dbus_error_is_set (&error))
+		if (!dbus_error_is_set (&error))
 		{
-			gs_debug ("%s raised:\n %s\n\n", error.name, error.message);
-			dbus_error_free (&error);
+			dbus_message_iter_init (reply, &reply_iter);
+			dbus_message_iter_get_basic (&reply_iter, &ssid);
+
+			dbus_message_unref (reply);
+			return g_strdup (ssid);
+		}
+
+		gs_debug ("%s raised:\n %s\n\n", error.name, error.message);
+		dbus_error_free (&error);
+
+		/* if getting session D-bus path by PID failed, try to get it using session Id */
+		message = dbus_message_new_method_call (SYSTEMD_LOGIND_SERVICE,
+							SYSTEMD_LOGIND_PATH,
+							SYSTEMD_LOGIND_INTERFACE,
+							"GetSession");
+		if (message == NULL)
+		{
+			gs_debug ("Couldn't allocate the dbus message");
 			return NULL;
 		}
 
-		dbus_message_iter_init (reply, &reply_iter);
-		dbus_message_iter_get_basic (&reply_iter, &ssid);
+		/* pass 'auto' as argument
+		 * loginctl does it this way
+		 * https://github.com/systemd/systemd/blob/v260/src/login/loginctl.c#L1059
+		 */
+		auto_session_id = "auto";
+		if (dbus_message_append_args (message,
+					      DBUS_TYPE_STRING,
+					      &auto_session_id, DBUS_TYPE_INVALID) == FALSE)
+		{
+			gs_debug ("Couldn't add args to the dbus message");
+			dbus_message_unref(message);
+			return NULL;
+		}
 
-		dbus_message_unref (reply);
+		/* FIXME: use async? */
+		reply = dbus_connection_send_with_reply_and_block (listener->priv->system_connection,
+			message,
+			-1, &error);
+		dbus_message_unref (message);
 
-		return g_strdup (ssid);
+		if (!dbus_error_is_set (&error))
+		{
+			dbus_message_iter_init (reply, &reply_iter);
+			dbus_message_iter_get_basic (&reply_iter, &ssid);
+
+			dbus_message_unref (reply);
+			return g_strdup (ssid);
+		}
+
+		gs_debug ("%s raised:\n %s\n\n", error.name, error.message);
+		dbus_error_free (&error);
+
+		return NULL;
 	}
 #endif
 


### PR DESCRIPTION
GetSessionByPID may fail in some cases. For example when it was started by D-bus.

Let's try to additionally get session D-bas path using GetSession method, like loginctl doint it

For more info read: https://github.com/mate-desktop/mate-screensaver/issues/306