### PR TITLE
Fix warning due to source being removed twice

### DIFF
--- a/src/gs-watcher-x11.c
+++ b/src/gs-watcher-x11.c
@@ -344,6 +344,10 @@ on_idle_timeout (GSWatcher *watcher)
 	_gs_watcher_set_session_idle_notice (watcher, FALSE);
 
 	/* try again if we failed i guess */
+	if (res)
+	{
+		watcher->priv->idle_id = 0;
+	}
 	return !res;
 }
 


### PR DESCRIPTION
Every time mate-screensaver is displayed, I get a message like `Source ID N was not found when attempting to remove it`.  Source IDs are reused over time, so this could potentially lead to a more serious issue in some cases.

This silences that warning, and removes the risk of the more serious issue.